### PR TITLE
Normalize theme.json settings and defaults

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -86,7 +86,7 @@ add_action( 'admin_enqueue_scripts', 'ucsc_add_admin_scripts' );
  * Enqueue fonts, styles and scripts.
  */
 function ucsc_add_scripts() {
-	wp_enqueue_style( 'ucsc-google-roboto-font', 'https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700|Roboto:100,300,400,500,700&display=swap', false );
+	wp_enqueue_style( 'ucsc-google-roboto-font', 'https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght@8..144,300;8..144,400;8..144,600;8..144,700;8..144,900&display=swap', false );
 	wp_register_script( 'ucsc-front', get_template_directory_uri() . '/build/theme.js', array(), wp_get_theme()->get( 'Version' ), true );
 	wp_enqueue_script( 'ucsc-front' );
 }

--- a/functions.php
+++ b/functions.php
@@ -86,7 +86,7 @@ add_action( 'admin_enqueue_scripts', 'ucsc_add_admin_scripts' );
  * Enqueue fonts, styles and scripts.
  */
 function ucsc_add_scripts() {
-	wp_enqueue_style( 'ucsc-google-roboto-font', 'https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght@8..144,300;8..144,400;8..144,600;8..144,700;8..144,900&display=swap', false );
+	wp_enqueue_style( 'ucsc-google-roboto-font', 'https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700|Roboto:100,300,400,500,700&display=swap', false );
 	wp_register_script( 'ucsc-front', get_template_directory_uri() . '/build/theme.js', array(), wp_get_theme()->get( 'Version' ), true );
 	wp_enqueue_script( 'ucsc-front' );
 }

--- a/parts/header-site.html
+++ b/parts/header-site.html
@@ -1,1 +1,1 @@
-<!-- wp:navigation {"textColor":"ucsc-primary-blue","className":"main-navigation","style":{"typography":{"fontStyle":"normal","fontWeight":"500","textTransform":"capitalize","fontSize":"1.1rem"}}} /-->
+<!-- wp:navigation {"textColor":"ucsc-primary-blue","className":"main-navigation","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"base"} /-->

--- a/src/scss/pages/_posts-pages.scss
+++ b/src/scss/pages/_posts-pages.scss
@@ -16,7 +16,7 @@
 
 .post-subtitle {
 	.post-subtitle-text {
-		font-size: var(--wp--preset--font-size--large);
+		font-size: var(--wp--preset--font-size--medium);
 		color: var(--wp--custom--color--light-gray);
 		margin: 0 0 1em;
 		line-height: 1.4;

--- a/theme.json
+++ b/theme.json
@@ -82,8 +82,7 @@
 			]
 		},
 		"layout": {
-			"contentSize": "67.5rem",
-			"wideSize": "90rem"
+			"contentSize": "80rem"
 		},
 		"spacing": {
 			"blockGap": false,
@@ -97,38 +96,38 @@
 			"fontSizes": [
 				{
 					"slug": "small",
-					"size": "0.9rem",
+					"size": "clamp(0.8rem, 0.22vw + 0.73rem, 0.9rem)",
 					"name": "Small"
 				},
 				{
-					"slug": "normal",
-					"size": "1rem",
-					"name": "Normal"
+					"slug": "base",
+					"size": "clamp(1rem, 0.28vw + 0.92rem, 1.13rem)",
+					"name": "Base"
 				},
 				{
 					"slug": "medium",
-					"size": "1.125rem",
+					"size": "clamp(1.25rem, 0.35vw + 1.15rem, 1.41rem)",
 					"name": "Medium"
 				},
 				{
 					"slug": "large",
-					"size": "1.25rem",
+					"size": "clamp(1.56rem, 0.43vw + 1.43rem, 1.76rem)",
 					"name": "Large"
 				},
 				{
 					"slug": "x-large",
-					"size": "1.5rem",
-					"name": "Extra Large"
+					"size": "clamp(1.95rem, 0.54vw + 1.79rem, 2.2rem)",
+					"name": "XL"
 				},
 				{
-					"slug": "huge",
-					"size": "2rem",
-					"name": "Huge"
+					"slug": "xx-large",
+					"size": "clamp(2.44rem, 0.68vw + 2.24rem, 2.75rem)",
+					"name": "XXL"
 				},
 				{
-					"slug": "gigantic",
-					"size": "6rem",
-					"name": "Gigantic"
+					"slug": "xxx-large",
+					"size": "clamp(3.05rem, 0.85vw + 2.8rem, 3.43rem)",
+					"name": "XXXL"
 				}
 			],
 			"fontFamilies": [
@@ -138,12 +137,12 @@
 					"name": "System Font"
 				},
 				{
-					"fontFamily": "Roboto, sans-serif",
+					"fontFamily": "'Roboto Flex', sans-serif",
 					"slug": "roboto",
 					"name": "Roboto"
 				},
 				{
-					"fontFamily": "Roboto Condensed, sans-serif",
+					"fontFamily": "'Roboto Condensed', sans-serif",
 					"slug": "roboto-condensed",
 					"name": "Roboto Condensed"
 				}
@@ -188,10 +187,16 @@
 			"line-height": {
 				"tiny": 1.15,
 				"small": 1.2,
-				"body": 1.428571429
+				"baseline": 1.5,
+				"medium": 1.68,
+				"large": 1.88
 			},
 			"spacing": {
-				"baseline": "2rem"
+				"baseline": "1rem",
+				"small": "max(1.25rem, 5vw)",
+				"medium": "clamp(2rem, 8vw, calc(4 * var(--wp--style--block-gap)))",
+				"large": "clamp(4rem, 10vw, 8rem)",
+				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
 			},
 			"border": {
 				"radius": "0.25rem"
@@ -214,8 +219,8 @@
 		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--roboto)",
-			"fontSize": "var(--wp--preset--font-size--normal)",
-			"lineHeight": "var(--wp--custom--line-height--body)"
+			"fontSize": "var(--wp--preset--font-size--base)",
+			"lineHeight": "var(--wp--custom--line-height--baseline)"
 		},
 		"elements": {
 			"link": {
@@ -228,7 +233,7 @@
 					"text": "var(--wp--custom--color--heading-text)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--huge)",
+					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"fontWeight": "600"
 				},
 				"spacing": {
@@ -245,7 +250,7 @@
 					"text": "var(--wp--custom--color--heading-text)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-large)",
+					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "600"
 				},
 				"spacing": {
@@ -262,7 +267,7 @@
 					"text": "var(--wp--custom--color--heading-text)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-large)",
+					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "600"
 				},
 				"spacing": {
@@ -279,7 +284,7 @@
 					"text": "var(--wp--custom--color--heading-text)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontSize": "var(--wp--preset--font-size--base)",
 					"fontWeight": "600"
 				},
 				"spacing": {
@@ -296,9 +301,9 @@
 					"text": "var(--wp--custom--color--heading-text)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"fontWeight": "600",
-					"lineHeight": "1"
+					"fontSize": "var(--wp--preset--font-size--base)",
+					"fontWeight": "400",
+					"lineHeight": "var(--wp--custom--line-height--tiny)"
 				},
 				"spacing": {
 					"margin": {
@@ -314,9 +319,9 @@
 					"text": "var(--wp--custom--color--heading-text)"
 				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--tiny)",
-					"fontWeight": "600",
-					"lineHeight": "1.1429"
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "400",
+					"lineHeight": "var(--wp--custom--line-height--tiny)"
 				},
 				"spacing": {
 					"margin": {
@@ -339,15 +344,15 @@
 					}
 				},
 				"typography": {
-					"lineHeight": "1.5",
-					"fontSize": "var(--wp--preset--font-size--normal)"
+					"lineHeight": "var(--wp--custom--line-height--baseline",
+					"fontSize": "var(--wp--preset--font-size--base)"
 				}
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "'Roboto Condensed', sans-serif",
+					"fontFamily": "var(--wp--preset--font-family--roboto-condensed)",
 					"fontWeight": "600",
-					"lineHeight": "1.2",
+					"lineHeight": "var(--wp--custom--line-height--small)",
 					"textTransform": "uppercase",
 					"fontSize": "2.8rem"
 				}
@@ -370,7 +375,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"lineHeight": "1.4"
+					"lineHeight": "var(--wp--custom--line-height--baseline)"
 				},
 				"spacing": {
 					"margin": {

--- a/theme.json
+++ b/theme.json
@@ -85,7 +85,7 @@
 			"contentSize": "80rem"
 		},
 		"spacing": {
-			"blockGap": false,
+			"blockGap": true,
 			"padding": true,
 			"margin": true,
 			"units": ["%", "px", "em", "rem", "vh", "vw"]
@@ -192,7 +192,7 @@
 				"large": 1.88
 			},
 			"spacing": {
-				"baseline": "1rem",
+				"baseline": "1.25rem",
 				"small": "max(1.25rem, 5vw)",
 				"medium": "clamp(2rem, 8vw, calc(4 * var(--wp--style--block-gap)))",
 				"large": "clamp(4rem, 10vw, 8rem)",
@@ -213,6 +213,9 @@
 		}
 	},
 	"styles": {
+		"spacing": {
+			"blockGap": "var(--wp--custom--spacing--baseline, 1.25rem)"
+		},
 		"color": {
 			"background": "var(--wp--preset--color--white)",
 			"text": "var(--wp--custom--color--default-text)"

--- a/theme.json
+++ b/theme.json
@@ -137,7 +137,7 @@
 					"name": "System Font"
 				},
 				{
-					"fontFamily": "\"Roboto Flex\", sans-serif",
+					"fontFamily": "\"Roboto\", sans-serif",
 					"slug": "roboto",
 					"name": "Roboto"
 				},

--- a/theme.json
+++ b/theme.json
@@ -137,12 +137,12 @@
 					"name": "System Font"
 				},
 				{
-					"fontFamily": "'Roboto Flex', sans-serif",
+					"fontFamily": "\"Roboto Flex\", sans-serif",
 					"slug": "roboto",
 					"name": "Roboto"
 				},
 				{
-					"fontFamily": "'Roboto Condensed', sans-serif",
+					"fontFamily": "\"Roboto Condensed\", sans-serif",
 					"slug": "roboto-condensed",
 					"name": "Roboto Condensed"
 				}
@@ -344,7 +344,7 @@
 					}
 				},
 				"typography": {
-					"lineHeight": "var(--wp--custom--line-height--baseline",
+					"lineHeight": "var(--wp--custom--line-height--baseline)",
 					"fontSize": "var(--wp--preset--font-size--base)"
 				}
 			},


### PR DESCRIPTION
This PR updates many of the settings in theme.json with sensible defaults.

- Type scale: Set fluid type scale with [clamped CSS variables](https://www.fluid-type-scale.com/calculate?minFontSize=16&minWidth=480&minRatio=1.25&maxFontSize=18&maxWidth=1200&maxRatio=1.25&steps=sm%2Cbase%2Cmd%2Clg%2Cxl%2Cxxl%2Cxxxl&baseStep=base&prefix=font-size&decimals=2&useRems=on&previewFont=Roboto)
- Normalize naming of sizes and spacing variables. Notably, `baseline` for most default spacing and sizes values