### PR TITLE
feat: 🎨 Add editor styles for width of separator block. Fixes #87

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'ucsc_setup' ) ) :
 		/*
 		* Load additional block styles.
 		*/
-		$styled_blocks = array( 'button', 'post-template', 'post-author', 'site-title', 'query-pagination', 'post-content', 'rss', 'post-title', 'post-comments', 'navigation', 'list' );
+		$styled_blocks = array( 'button', 'post-template', 'post-author', 'site-title', 'query-pagination', 'post-content', 'rss', 'post-title', 'post-comments', 'navigation', 'list', 'separator');
 		foreach ( $styled_blocks as $block_name ) {
 			$args = array(
 				'handle' => "ucsc-$block_name",

--- a/wp-blocks/separator.css
+++ b/wp-blocks/separator.css
@@ -1,0 +1,15 @@
+.wp-block-separator.has-background:not(.is-style-dots) {
+	height: 2px;
+}
+
+.wp-block-separator:not(.is-style-wide):not(.is-style-dots).is-style-ucsc-small {
+	width: 20%;
+}
+
+.wp-block-separator:not(.is-style-wide):not(.is-style-dots).is-style-ucsc-medium {
+	width: 45%;
+}
+
+.wp-block-separator:not(.is-style-wide):not(.is-style-dots).is-style-ucsc-large {
+	width: 66%;
+}

--- a/wp-blocks/styles.js
+++ b/wp-blocks/styles.js
@@ -3,6 +3,7 @@
  * 	Remove default button styles.
  */
 wp.domReady(() => {
+	// Styles for buttons
 	wp.blocks.registerBlockStyle("core/button", {
 		name: "ucsc-blue",
 		label: "Blue",
@@ -16,5 +17,24 @@ wp.domReady(() => {
 	});
 	wp.blocks.unregisterBlockStyle("core/button", "outline");
 	wp.blocks.unregisterBlockStyle("core/button", "fill");
+
+	// Styles for separators
+	wp.blocks.registerBlockStyle("core/separator", {
+		name: "ucsc-small",
+		label: "Small",
+		isDefault: true,
+		style_handle: "ucsc-separator",
+	});
+	wp.blocks.registerBlockStyle("core/separator", {
+		name: "ucsc-medium",
+		label: "Medium",
+		style_handle: "ucsc-separator",
+	});
+	wp.blocks.registerBlockStyle("core/separator", {
+		name: "ucsc-large",
+		label: "Large",
+		style_handle: "ucsc-separator",
+	});
+	wp.blocks.unregisterBlockStyle("core/separator", "default");
 	wp.blocks.unregisterBlockStyle("core/separator", "dots");
 });


### PR DESCRIPTION
Adds small, medium, and large width sizes along side the 'wide' setting

Removes the 'default' style. Any existing separator with that setting will need to be updated.