### PR TITLE
fix: :bug: Remove Safari/Webkit search form magnifying glass #132

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'ucsc_setup' ) ) :
 		/*
 		* Load additional block styles.
 		*/
-		$styled_blocks = array( 'button', 'post-template', 'post-author', 'site-title', 'query-pagination', 'post-content', 'rss', 'post-title', 'post-comments', 'navigation', 'list', 'separator', 'latest-posts', 'quote', 'image');
+		$styled_blocks = array( 'button', 'post-template', 'post-author', 'site-title', 'query-pagination', 'post-content', 'rss', 'post-title', 'post-comments', 'navigation', 'list', 'separator', 'latest-posts', 'quote', 'image', 'search');
 		foreach ( $styled_blocks as $block_name ) {
 			$args = array(
 				'handle' => "ucsc-$block_name",

--- a/src/scss/theme-regions/_ucsc-header.scss
+++ b/src/scss/theme-regions/_ucsc-header.scss
@@ -37,6 +37,4 @@
 		&:active {
 			outline: 2px solid var(--wp--preset--color--ucsc-primary-blue);
 		}
-	}
-
 }

--- a/wp-blocks/search.css
+++ b/wp-blocks/search.css
@@ -1,0 +1,3 @@
+.wp-block-search input[type="search"] {
+	-webkit-appearance: none;
+}


### PR DESCRIPTION
I created a new `wp-blocks/search.css` file and included it via `functions.php` rather than continue in `_site-header.scss` because we'd want this removed wherever a user inserts a search block.

I no longer have access to BrowserStack, so I couldn't test this on Safari. @knice would you be able to pull this branch down and test it before merging?