### PR TITLE
Content area layout width increase to 1280px

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -260,6 +260,7 @@ function ucsc_breadcrumbs_constructor() {
 		'labels'         => $labels,
 		'show_on_front'  => true,
 		'show_trail_end' => false,
+		'container_class'=> 'breadcrumbs alignwide'
 	);
 	return Hybrid\Breadcrumbs\Trail::render( $args );
 }
@@ -335,7 +336,7 @@ add_action(
 add_action( 'wp_body_open', 'ucsc_add_custom_body_open_code' );
 
 function ucsc_add_custom_body_open_code() {
-	echo '<trss-ucsc-header use-logo="true" search-action="/" search-query="s" style="--trss-content-width:72rem;"></trss-ucsc-header>';
+	echo '<trss-ucsc-header use-logo="true" search-action="/" search-query="s" style="--trss-content-width:80rem;"></trss-ucsc-header>';
 }
 
 add_action( 'wp_footer', 'ucsc_add_custom_body_close_code' );

--- a/parts/site-footer.html
+++ b/parts/site-footer.html
@@ -1,32 +1,40 @@
-<!-- wp:group {"className":"site-footer__inner","layout":{"inherit":true}} -->
-<div class="wp-block-group site-footer__inner ucsc-layout-row">
-	<!-- wp:columns -->
-	<div class="wp-block-columns">
-		<!-- wp:column -->
-		<div class="wp-block-column">
-			<!-- wp:site-title {"level":0,"fontSize":"medium"} /-->
-		</div>
+<!-- wp:group {"className":"site-footer__inner ucsc-layout-row","layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group site-footer__inner ucsc-layout-row"><!-- wp:columns {"align":"wide"} -->
+	<div class="wp-block-columns alignwide"><!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:site-title {"level":0,"textColor":"darkest-gray","fontSize":"two"} /--></div>
 		<!-- /wp:column -->
 
 		<!-- wp:column -->
-		<div class="wp-block-column">
-			<!-- wp:list {"fontSize":"small"} -->
-			<ul class="has-small-font-size">
-				<li>Contact us</li>
-				<li>Undergraduate programs</li>
-				<li>Prospective students</li>
+		<div class="wp-block-column"><!-- wp:list -->
+			<ul><!-- wp:list-item -->
+				<li>Add your link</li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li>Add your link</li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li>Add your link</li>
+				<!-- /wp:list-item -->
 			</ul>
 			<!-- /wp:list -->
 		</div>
 		<!-- /wp:column -->
 
 		<!-- wp:column -->
-		<div class="wp-block-column">
-			<!-- wp:list {"fontSize":"small"} -->
-			<ul class="has-small-font-size">
-				<li>Graduate programs</li>
-				<li>Faculty</li>
-				<li>Staff portal</li>
+		<div class="wp-block-column"><!-- wp:list -->
+			<ul><!-- wp:list-item -->
+				<li>Add your link</li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li>Add your link</li>
+				<!-- /wp:list-item -->
+
+				<!-- wp:list-item -->
+				<li>Add your link</li>
+				<!-- /wp:list-item -->
 			</ul>
 			<!-- /wp:list -->
 		</div>
@@ -40,7 +48,7 @@
 
 				<!-- wp:social-link {"url":"instagram.com","service":"instagram"} /-->
 
-				<!-- wp:social-link {"url":"#","service":"facebook"} /-->
+				<!-- wp:social-link {"url":"facebook.com","service":"facebook"} /-->
 
 				<!-- wp:social-link {"url":"youtube.com","service":"youtube"} /-->
 

--- a/parts/site-header.html
+++ b/parts/site-header.html
@@ -1,22 +1,17 @@
-<!-- wp:group -->
-<div class="wp-block-group">
-	<!-- wp:group {"className":"site-header__inner is-layout-constrained","layout":{"inherit":true,"type":"constrained"}} -->
-	<div class="wp-block-group site-header__inner is-layout-constrained">
-		<!-- wp:site-title {"className":"site-header__title"} /-->
-	</div>
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<div class="wp-block-group alignwide"><!-- wp:site-title {"level":0} /--></div>
 	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->
 
-	<!-- wp:separator {"backgroundColor":"ucsc-primary-yellow","className":"is-style-wide site-header__separator"} -->
-	<hr
-		class="wp-block-separator has-text-color has-ucsc-primary-yellow-color has-alpha-channel-opacity has-ucsc-primary-yellow-background-color has-background is-style-wide site-header__separator" />
-	<!-- /wp:separator -->
+<!-- wp:separator {"backgroundColor":"ucsc-primary-yellow","className":"is-style-wide site-header__separator"} -->
+<hr
+	class="wp-block-separator has-text-color has-ucsc-primary-yellow-color has-alpha-channel-opacity has-ucsc-primary-yellow-background-color has-background is-style-wide site-header__separator" />
+<!-- /wp:separator -->
 
-	<!-- wp:group {"style":{"border":{"width":"0px","style":"none"}},"className":"site-header__inner is-layout-constrained","layout":{"inherit":true,"type":"constrained"}} -->
-	<div class="wp-block-group site-header__inner is-layout-constrained" style="border-style:none;border-width:0px">
-
-		<!-- wp:navigation {"textColor":"ucsc-primary-blue","className":"site-header__navigation"} /-->
-
-	</div>
-	<!-- /wp:group -->
+<!-- wp:group {"style":{"border":{"width":"0px","style":"none"}},"className":"site-header__inner is-layout-constrained","layout":{"inherit":true,"type":"constrained","justifyContent":"center"}} -->
+<div class="wp-block-group site-header__inner is-layout-constrained" style="border-style:none;border-width:0px">
+	<!-- wp:navigation {"textColor":"ucsc-primary-blue","align":"wide","className":"site-header__navigation","layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} /-->
 </div>
 <!-- /wp:group -->

--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -14,49 +14,6 @@ body {
 	grid-template-rows: auto 1fr auto;
 }
 
-.ucsc-layout-row,
-.is-layout-constrained {
-	padding: 0 2rem;
-}
-
-/**
-	Fixed width content window
-	These rules set a fixed width of 72rem
-	in the editor and live page window
-	while still allowing full-width elements
-with the .alignfull class
-*/
-.is-root-container {
-	max-width: $content-size;
-	margin-left: auto;
-	margin-right: auto;
-}
-
-.wp-block-post-content > .alignfull,
-.block-editor-block-list__layout.is-root-container > .alignfull {
-	margin-left: calc(-1 * var(--wp--custom--spacing--baseline)) !important;
-	margin-right: calc(-1 * var(--wp--custom--spacing--baseline)) !important;
-
-	width: calc(100% + var(--wp--custom--spacing--baseline) + var(--wp--custom--spacing--baseline)) !important;
-}
-
-@media screen and (min-width: 84rem) {
-
-	.ucsc-layout-row {
-		padding: 0;
-	}
-
-	.is-root-container,
-	.wp-site-blocks {
-		padding-left: 0;
-		padding-right: 0;
-	}
-
-	.wp-block-post-content > .alignfull,
-	.block-editor-block-list__layout.is-root-container > .alignfull {
-		width: 100vw !important;
-		max-width: 100vw !important;
-		margin-left: calc(50% - 50vw) !important;
-		margin-right: auto !important;
-	}
+.editor-styles-wrapper {
+	margin: 0 auto;
 }

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -7,7 +7,6 @@
 //===============================
 @import "base/normalize";
 @import "base/svg";
-@import "base/alignments";
 @import "base/layout";
 
 // Elements

--- a/style.css
+++ b/style.css
@@ -14,3 +14,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: ucsc-2022
 GitHub Theme URI: http://github.com/ucsc/ucsc-2022
 */
+
+body * {
+	box-sizing: border-box;
+}

--- a/templates/single.html
+++ b/templates/single.html
@@ -7,7 +7,49 @@
 	<!-- wp:post-date /-->
 	<!-- wp:post-author {"showAvatar":false,"showBio":false,"style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} /-->
 	<!-- wp:post-content /-->
-	<!-- wp:post-comments /-->
+
+	<!-- wp:comments -->
+	<div class="wp-block-comments"><!-- wp:comments-title {"fontSize":"two"} /-->
+
+		<!-- wp:comment-template -->
+		<!-- wp:columns -->
+		<div class="wp-block-columns"><!-- wp:column {"width":"40px"} -->
+			<div class="wp-block-column" style="flex-basis:40px">
+				<!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /-->
+			</div>
+			<!-- /wp:column -->
+
+			<!-- wp:column -->
+			<div class="wp-block-column"><!-- wp:comment-author-name {"fontSize":"small"} /-->
+
+				<!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"flex"}} -->
+				<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px">
+					<!-- wp:comment-date {"fontSize":"small"} /-->
+
+					<!-- wp:comment-edit-link {"fontSize":"small"} /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:comment-content /-->
+
+				<!-- wp:comment-reply-link {"fontSize":"small"} /-->
+			</div>
+			<!-- /wp:column -->
+		</div>
+		<!-- /wp:columns -->
+		<!-- /wp:comment-template -->
+
+		<!-- wp:comments-pagination -->
+		<!-- wp:comments-pagination-previous /-->
+
+		<!-- wp:comments-pagination-numbers /-->
+
+		<!-- wp:comments-pagination-next /-->
+		<!-- /wp:comments-pagination -->
+
+		<!-- wp:post-comments-form /-->
+	</div>
+	<!-- /wp:comments -->
 
 </main>
 <!-- /wp:group -->

--- a/theme.json
+++ b/theme.json
@@ -13,6 +13,7 @@
 	],
 	"settings": {
 		"appearanceTools": true,
+		"useRootPaddingAwareAlignments": true,
 		"color": {
 			"custom": false,
 			"link": true,
@@ -110,10 +111,54 @@
 			"contentSize": "80rem"
 		},
 		"spacing": {
-			"blockGap": true,
-			"padding": true,
-			"margin": true,
-			"units": ["%", "px", "em", "rem", "vh", "vw"]
+			"spacingScale": {
+				"steps": 0
+			},
+			"spacingSizes": [
+				{
+					"size": "clamp(1rem, 2vw, 1.5rem)",
+					"slug": "20",
+					"name": "1"
+				},
+				{
+					"size": "clamp(1.5rem, 5vw, 2rem)",
+					"slug": "30",
+					"name": "2"
+				},
+				{
+					"size": "clamp(1.8rem, 1.8rem + ((1vw - 0.48rem) * 2.885), 3rem)",
+					"slug": "40",
+					"name": "3"
+				},
+				{
+					"size": "clamp(2.5rem, 8vw, 4.5rem)",
+					"slug": "50",
+					"name": "4"
+				},
+				{
+					"size": "clamp(3.75rem, 10vw, 7rem)",
+					"slug": "60",
+					"name": "5"
+				},
+				{
+					"size": "clamp(5rem, 5.25rem + ((1vw - 0.48rem) * 9.096), 8rem)",
+					"slug": "70",
+					"name": "6"
+				},
+				{
+					"size": "clamp(7rem, 14vw, 11rem)",
+					"slug": "80",
+					"name": "7"
+				}
+			],
+			"units": [
+				"%",
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw"
+			]
 		},
 		"typography": {
 			"lineHeight": true,
@@ -265,7 +310,13 @@
 	},
 	"styles": {
 		"spacing": {
-			"blockGap": "var(--wp--custom--spacing--baseline)"
+			"blockGap": "var(--wp--preset--font-size--one)",
+			"padding": {
+				"top": "0",
+				"right": "1rem",
+				"bottom": "0",
+				"left": "1rem"
+			}
 		},
 		"color": {
 			"background": "var(--wp--preset--color--white)",
@@ -351,7 +402,7 @@
 					"fontSize": "var(--wp--preset--font-size--one)"
 				},
 				"spacing": {
-					"blockGap":"var:preset|spacing|60"
+					"blockGap": "var:preset|spacing|60"
 				}
 			},
 			"core/post-date": {
@@ -407,10 +458,10 @@
 				},
 				"spacing": {
 					"padding": {
-						"top": "var(--wp--preset--spacing--30)",
-						"right": "var(--wp--preset--spacing--60)",
-						"bottom": "var(--wp--preset--spacing--30)",
-						"left": "var(--wp--preset--spacing--60)"
+						"top": "var(--wp--preset--spacing--20)",
+						"right": "var(--wp--preset--spacing--30)",
+						"bottom": "var(--wp--preset--spacing--20)",
+						"left": "var(--wp--preset--spacing--30)"
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #191 

- Sets content area width to 80rem (1280px)
- Adds 'use root padding' setting to theme.json
- Adds set padding sizes for block padding settings
- Adjusts default padding on some elements 