### PR TITLE
UCSC-67 BE: WP Admin setting to set logo/tagline in main header/footer

### DIFF
--- a/.deploy/composer.json
+++ b/.deploy/composer.json
@@ -10,7 +10,7 @@
 	},
 	"require": {
 		"php": "^7.4",
-		"johnpbloch/wordpress": "^6.1.1",
+		"johnpbloch/wordpress": "^6.2",
 		"wpackagist-theme/twentytwentyone": "^1.5"
 	},
 	"extra": {

--- a/functions.php
+++ b/functions.php
@@ -312,6 +312,10 @@ if ( file_exists( get_theme_file_path( 'lib/acf.php' ) ) ) {
 	include get_theme_file_path( 'lib/acf.php' );
 }
 
+if ( file_exists( get_theme_file_path( 'lib/mimes.php' ) ) ) {
+	include get_theme_file_path( 'lib/mimes.php' );
+}
+
 /**
  * Enqueue theme block editor style script to modify the "styles" available for blocks in the editor.
  */

--- a/lib/mimes.php
+++ b/lib/mimes.php
@@ -1,0 +1,5 @@
+<?php
+
+add_filter('upload_mimes', function ( array $mimes ) {
+	return array_merge( $mimes, [ 'svg' => 'image/svg+xml' ] );
+}, 10, 1 );

--- a/parts/site-header.html
+++ b/parts/site-header.html
@@ -1,10 +1,10 @@
 <!-- wp:group {"backgroundColor":"ucsc-primary-blue","layout":{"type":"constrained"}} -->
 <div class="wp-block-group has-ucsc-primary-blue-background-color has-background"><!-- wp:columns -->
-	<div class="wp-block-columns"><!-- wp:column -->
-		<div class="wp-block-column"><!-- wp:site-title {"textColor":"white"} /--></div>
+	<div class="wp-block-columns"><!-- wp:column {"style":{"spacing":{"padding":{"right":"0"}}}} -->
+		<div class="wp-block-column"><!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"textTransform":"uppercase"}},"textColor":"white"} /--></div>
 		<!-- /wp:column -->
 
-		<!-- wp:column -->
+		<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"0","bottom":"var:preset|spacing|20","left":"0"}}},"layout":{"type":"default"}} -->
 		<div class="wp-block-column"><!-- wp:site-tagline {"textColor":"ucsc-primary-yellow"} /--></div>
 		<!-- /wp:column --></div>
 	<!-- /wp:columns --></div>

--- a/parts/site-header.html
+++ b/parts/site-header.html
@@ -1,8 +1,13 @@
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignwide"><!-- wp:site-title {"level":0} /--></div>
-	<!-- /wp:group -->
-</div>
+<!-- wp:group {"backgroundColor":"ucsc-primary-blue","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-ucsc-primary-blue-background-color has-background"><!-- wp:columns -->
+	<div class="wp-block-columns"><!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:site-title {"textColor":"white"} /--></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:site-tagline {"textColor":"ucsc-primary-yellow"} /--></div>
+		<!-- /wp:column --></div>
+	<!-- /wp:columns --></div>
 <!-- /wp:group -->
 
 <!-- wp:separator {"backgroundColor":"ucsc-primary-yellow","className":"is-style-wide site-header__separator"} -->


### PR DESCRIPTION
## What

Change site-header.html template. Add 2 areas for title/logo and tagline

## Ticket

[UCSC-67](https://moderntribe.atlassian.net/browse/UCSC-67) BE: WP Admin setting to set logo/tagline in main header/footer

## Screenshots

![CA4456A9-3521-4A2E-98FC-167496BADB1B](https://user-images.githubusercontent.com/25453018/231132624-07da1946-f040-410a-8bc5-271cfb03c792.jpeg)
