### PR TITLE
Feature/ucsc 84/breadcrumb hero

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -263,7 +263,7 @@ function ucsc_breadcrumbs_constructor() {
 		'labels'         => $labels,
 		'show_on_front'  => true,
 		'show_trail_end' => false,
-		'container_class'=> 'breadcrumbs alignwide'
+		'container_class'=> 'ucsc-page-header__breadcrumbs alignwide'
 	);
 	return Hybrid\Breadcrumbs\Trail::render( $args );
 }
@@ -279,9 +279,9 @@ function ucsc_add_breadcrumbs( $block_content = '', $block = array() ) {
 	if ( ucsc_breadcrumbs_constructor() ) {
 		$breadcrumbs = ucsc_breadcrumbs_constructor();
 	}
-	if ( is_singular() && isset( $breadcrumbs ) ) {
+	if ( is_singular() && isset( $breadcrumbs ) && is_page_template( 'page-no-title-with-breadcrumbs' ) ) {
 		if ( isset( $block['blockName'] ) && 'core/post-title' === $block['blockName'] ) {
-			if ( isset( $block['attrs']['level'] ) && isset( $block['attrs']['className'] ) && $block['attrs']['className'] === 'primary-post-title' ) {
+			if ( isset( $block['attrs']['level'] ) ) {
 				$html = str_replace( $block_content, $breadcrumbs . $block_content, $block_content );
 				return $html;
 			}

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -7,11 +7,11 @@ add_action( 'init', function () {
 	// Register Block Categories
 	register_block_pattern_category(
 		'ucsc',
-		array( 'label' => __( 'UCSC', 'my-plugin' ) )
+		array( 'label' => __( 'UCSC', 'ucsc' ) )
 	);
 
 	register_block_pattern_category(
 		'hero',
-		array( 'label' => __( 'Hero', 'my-plugin' ) )
+		array( 'label' => __( 'Hero', 'ucsc' ) )
 	);
 } );

--- a/patterns/page-header-breadcrumbs.php
+++ b/patterns/page-header-breadcrumbs.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Title: Page Header w/ Breadcrumbs
+ * Slug: ucsc-2022/page-header
+ * Block Types: core/cover, core/heading
+ * Categories: ucsc
+ */
+?>
+
+<!-- wp:group {"align":"full","className":"ucsc-page-header","layout":{"type":"default"},"fontSize":"base"} -->
+<div class="wp-block-group alignfull ucsc-page-header has-base-font-size">
+	<!-- wp:cover {"dimRatio":50,"contentPosition":"center center","isDark":false,"className":"ucsc-page-header__content","style":{"spacing":{"padding":{"top":"var:preset|spacing|50"}}}} -->
+	<div class="wp-block-cover is-light ucsc-page-header__content" style="padding-top:var(--wp--preset--spacing--50)">
+		<span aria-hidden="true" class="wp-block-cover__background has-background-dim"></span>
+		<div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"default"}} -->
+			<div class="wp-block-group">
+				<!-- wp:post-title {"level":1,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"ucsc-primary-yellow","textColor":"ucsc-primary-blue","className":"ucsc-page-header__title primary-post-title","fontSize":"seven"} /--></div>
+			<!-- /wp:group --></div>
+	</div>
+	<!-- /wp:cover --></div>
+<!-- /wp:group -->

--- a/src/scss/block-patterns/_page-header-breadcrumbs.scss
+++ b/src/scss/block-patterns/_page-header-breadcrumbs.scss
@@ -1,6 +1,6 @@
 /* BLOCK PATTERN: Homepage Hero */
 
-.uscs-page-header {
+.ucsc-page-header {
 	margin: 0;
 }
 

--- a/src/scss/block-patterns/_page-header-breadcrumbs.scss
+++ b/src/scss/block-patterns/_page-header-breadcrumbs.scss
@@ -1,0 +1,28 @@
+/* BLOCK PATTERN: Homepage Hero */
+
+.uscs-page-header {
+	margin: 0;
+}
+
+.ucsc-page-header__content {
+
+	.page-template-page-no-title-with-breadcrumbs & {
+		padding-top: var(--wp--preset--spacing--20) !important;
+	}
+
+	.wp-block-cover__inner-container {
+		align-self: flex-start;
+
+		@include content-width;
+
+		.page-template-page-no-title-with-breadcrumbs & {
+			display: grid;
+			grid-template-columns: 1fr;
+			gap: var(--wp--preset--spacing--20);
+		}
+	}
+}
+
+.ucsc-page-header__title {
+	display: inline-block;
+}

--- a/src/scss/components/_breadbrumbs.scss
+++ b/src/scss/components/_breadbrumbs.scss
@@ -1,15 +1,18 @@
 //BREADCRUMBS
 
 // Wrapper element.
-.breadcrumbs {
-	font-size: calc(var(--wp--preset--font-size--small) * 0.85);
+.ucsc-page-header__breadcrumbs {
+	font-size: var(--wp--preset--font-size--one);
+}
 
+.breadcrumbs {
 	// Title. Note that this is the heading that says "Browse:". The code
 	// puts it inline with the trail.
 	&__title {
 		display: inline-block;
 		margin: 0 0 1.5rem;
 		font-size: inherit;
+		color: inherit;
 	}
 
 	// List.
@@ -24,25 +27,31 @@
 	&__crumb {
 		display: inline-block;
 
+
 		a {
-			border-bottom: 1px solid var(--wp--custom--color--flourish);
+			border-bottom: 0;
 			text-decoration: none;
-			color: var(--wp--custom--color--site-title);
+			font-size: 0.82rem;
+			line-height: 20px;
+			font-weight: 700;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+			color: var(--wp--preset--color--white);
 
 			&:active,
 			&:focus,
 			&:hover {
-				border-bottom:
-					1px solid
-					var(--wp--preset--color--ucsc-secondary-blue);
+				border-bottom: 1px solid;
 				text-decoration: none;
 			}
 		}
 
 		// Add separators.
 		&::after {
-			content: "\002F";
+			content: ">";
 			padding: 0 0.25em;
+			font-size: 0.82rem;
+			color: var(--wp--preset--color--white);
 		}
 
 		&:last-of-type::after {

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -36,3 +36,4 @@
 // Blocks and Block Patterns
 //===============================
 @import "block-patterns/homepage-hero";
+@import "block-patterns/page-header-breadcrumbs";

--- a/src/scss/utilities/_mixins.scss
+++ b/src/scss/utilities/_mixins.scss
@@ -16,3 +16,9 @@ $content-size: 80rem;
 	}
 
 }
+
+@mixin content-width($size: var(--max-container-1280)) {
+	width: 100%;
+	max-width: $size;
+	margin: 0 auto !important;
+}

--- a/src/scss/utilities/_variables.scss
+++ b/src/scss/utilities/_variables.scss
@@ -1,1 +1,5 @@
 /* Utility Variables */
+:root {
+	--max-container-1280: 1280px;
+	--max-container-1440: 1440px;
+}

--- a/templates/page-no-title-with-breadcrumbs.html
+++ b/templates/page-no-title-with-breadcrumbs.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header","theme":"ucsc-2022","tagName":"header","className":"header-region"} /-->
+
+<!-- wp:group {"tagName":"main", "className":"content-region"} -->
+<main class="wp-block-group content-region">
+
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"ucsc-2022","tagName":"footer","className":"footer-region"} /-->

--- a/templates/page-no-title.html
+++ b/templates/page-no-title.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header","theme":"ucsc-2022","tagName":"header","className":"header-region"} /-->
+
+<!-- wp:group {"tagName":"main", "className":"content-region"} -->
+<main class="wp-block-group content-region">
+
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"ucsc-2022","tagName":"footer","className":"footer-region"} /-->


### PR DESCRIPTION
## What does this do/fix?

- Adds a new block pattern for a page header hero with breadcrumbs.
- Adds two new templates for a page with no title. One with breadcrumbs support and one without.
- Leveraged existing breadcrumb functions and modified them to work with the new block pattern and templates.
- Added new variables and mixins to help with content width restrictions in blocks without width support.
- Added styles for the new block pattern.
- Updated styles for breadcrumbs.
- Fixed an error with the localization domain on the blocks.php file.

## QA

Links to relevant issues
- [Link to ticket](https://moderntribe.atlassian.net/browse/UCSC-84)
- [Link to the screencast](https://www.loom.com/share/941dd8579b53432ca39a677adba429b2)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests
- [ ] No, I need help figuring out how to write the tests.

