### PR TITLE
Feature/ucsc 95/card patterns

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,6 +8,8 @@
  * @since UCSC 1.0.0
  */
 
+use Image_Sizes;
+
 if ( ! function_exists( 'ucsc_setup' ) ) :
 
 	/**
@@ -315,13 +317,24 @@ if ( file_exists( get_theme_file_path( 'lib/acf.php' ) ) ) {
 	include get_theme_file_path( 'lib/acf.php' );
 }
 
-include get_theme_file_path( 'lib/blocks.php' );
-
 /**
  * Register Block Pattern Customizations
  */
 if ( file_exists( get_theme_file_path( 'lib/blocks.php' ) ) ) {
 	include get_theme_file_path( 'lib/blocks.php' );
+}
+
+/**
+ * Register Image Sizes
+ */
+if ( file_exists( get_theme_file_path( 'lib/image_sizes.php' ) ) ) {
+	include get_theme_file_path( 'lib/image_sizes.php' );
+
+	add_action( 'after_setup_theme', function () {
+		$images = new Image_Sizes();
+		$images->register_sizes();
+		$images->register_size_names();
+	});
 }
 
 /**

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -14,4 +14,9 @@ add_action( 'init', function () {
 		'hero',
 		array( 'label' => __( 'Hero', 'ucsc' ) )
 	);
+
+	register_block_pattern_category(
+		'cards',
+		array( 'label' => __( 'Cards', 'ucsc' ) )
+	);
 } );

--- a/lib/image_sizes.php
+++ b/lib/image_sizes.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+class Image_Sizes {
+
+	public const SQUARE_SMALL = 'square-small';
+	public const SQUARE_MEDIUM = 'square-medium';
+	public const SQUARE_LARGE = 'square-large';
+	public const SIXTEEN_NINE = 'sixteen-nine';
+	public const SIXTEEN_NINE_SMALL = 'sixteen-nine-small';
+	public const SIXTEEN_NINE_LARGE = 'sixteen-nine-large';
+
+	/**
+	 * @var array<string, array<string, int|bool>>
+	 */
+	private array $sizes = [
+		self::SQUARE_SMALL => [
+			'width' => 240,
+			'height' => 240,
+			'crop' => true,
+		],
+		self::SQUARE_MEDIUM => [
+			'width' => 400,
+			'height' => 400,
+			'crop' => true,
+		],
+		self::SQUARE_LARGE => [
+			'width' => 800,
+			'height' => 800,
+			'crop' => true,
+		],
+		self::SIXTEEN_NINE_SMALL => [
+			'width' => 400,
+			'height' => 248,
+			'crop' => true,
+		],
+		self::SIXTEEN_NINE => [
+			'width' => 800,
+			'height' => 496,
+			'crop' => true,
+		],
+		self::SIXTEEN_NINE_LARGE => [
+			'width' => 1200,
+			'height' => 744,
+			'crop' => true,
+		],
+	];
+
+	/**
+	 * @action after_setup_theme
+	 */
+	public function register_sizes(): void {
+		foreach ( $this->sizes as $key => $attributes ) {
+			add_image_size( $key, $attributes['width'], $attributes['height'], $attributes['crop'] );
+		}
+	}
+
+	public function register_size_names(): void {
+		add_filter( 'image_size_names_choose', function ( array $sizes ) {
+			$ucsc_sizes = [
+				self::SQUARE_SMALL => __('Square Small', 'ucsc'),
+				self::SQUARE_MEDIUM => __('Square Medium', 'ucsc'),
+				self::SQUARE_LARGE => __('Square Large', 'ucsc'),
+				self::SIXTEEN_NINE_SMALL => __('16:9 Small', 'ucsc'),
+				self::SIXTEEN_NINE => __('16:9 Medium', 'ucsc'),
+				self::SIXTEEN_NINE_LARGE => __('16:9 Large', 'ucsc'),
+			];
+
+			foreach ( $ucsc_sizes as $key => $value) {
+				$sizes[ $key ] = $value;
+			}
+
+			return $sizes;
+		} );
+	}
+
+}

--- a/patterns/card-grid-2-columns.php
+++ b/patterns/card-grid-2-columns.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Title: Card Grid 2 Columns
+ * Slug: ucsc-2022/card-grid-2-columns
+ * Categories: ucsc, cards
+ */
+?>
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50"}}},"className":"ucsc__2-col-card-grid","layout":{"type":"constrained"}} -->
+<div class="wp-block-group ucsc__2-col-card-grid" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading -->
+	<h2 class="wp-block-heading">2-Column Card Grid</h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"className":"ucsc__card-grid"} -->
+	<div class="wp-block-columns ucsc__card-grid"><!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+			<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image -->
+				<figure class="wp-block-image"><img alt=""/></figure>
+				<!-- /wp:image -->
+
+				<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+				<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Card Title</h3>
+				<!-- /wp:heading -->
+
+				<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+				<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vel ante nec diam placerat vulputate. Fusce ut dui sagittis lacus rutrum tristique ut vitae leo. Phasellus ultrices nunc nec tempus condimentum. Sed facilisis scelerisque lobortis. Suspendisse potenti. Duis iaculis at mi eget porttitor. Donec elementum lacus ut fermentum aliquet.</p>
+				<!-- /wp:paragraph -->
+
+				<!-- wp:buttons {"className":"ucsc__card-cta","style":{"spacing":{"blockGap":"0"}}} -->
+				<div class="wp-block-buttons ucsc__card-cta"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+					<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button">Call To Action</a></div>
+					<!-- /wp:button --></div>
+				<!-- /wp:buttons --></div>
+			<!-- /wp:group --></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+			<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image -->
+				<figure class="wp-block-image"><img alt=""/></figure>
+				<!-- /wp:image -->
+
+				<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+				<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Card Title</h3>
+				<!-- /wp:heading -->
+
+				<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+				<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vel ante nec diam placerat vulputate. Fusce ut dui sagittis lacus rutrum tristique ut vitae leo. Phasellus ultrices nunc nec tempus condimentum. Sed facilisis scelerisque lobortis. Suspendisse potenti. Duis iaculis at mi eget porttitor. Donec elementum lacus ut fermentum aliquet.</p>
+				<!-- /wp:paragraph -->
+
+				<!-- wp:buttons {"className":"ucsc__card-cta","style":{"spacing":{"blockGap":"0"}}} -->
+				<div class="wp-block-buttons ucsc__card-cta"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+					<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button">Call To Action</a></div>
+					<!-- /wp:button --></div>
+				<!-- /wp:buttons --></div>
+			<!-- /wp:group --></div>
+		<!-- /wp:column --></div>
+	<!-- /wp:columns --></div>
+<!-- /wp:group -->

--- a/patterns/card-grid-3-columns.php
+++ b/patterns/card-grid-3-columns.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Title: Card Grid 3 Columns
+ * Slug: ucsc-2022/card-grid-3-columns
+ * Categories: ucsc, cards
+ */
+?>
+
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50"}}},"className":"ucsc__2-col-card-grid","layout":{"type":"constrained","contentSize":"1280px"}} -->
+<div class="wp-block-group alignfull ucsc__2-col-card-grid" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading -->
+	<h2 class="wp-block-heading">2-Column Card Grid</h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"className":"ucsc__card-grid"} -->
+	<div class="wp-block-columns ucsc__card-grid"><!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+			<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image -->
+				<figure class="wp-block-image"><img alt=""/></figure>
+				<!-- /wp:image -->
+
+				<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+				<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Card Title</h3>
+				<!-- /wp:heading -->
+
+				<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+				<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vel ante nec diam placerat vulputate. Fusce ut dui sagittis lacus rutrum tristique ut vitae leo. Phasellus ultrices nunc nec tempus condimentum. Sed facilisis scelerisque lobortis. Suspendisse potenti. Duis iaculis at mi eget porttitor. Donec elementum lacus ut fermentum aliquet.</p>
+				<!-- /wp:paragraph -->
+
+				<!-- wp:buttons {"className":"ucsc__card-cta","style":{"spacing":{"blockGap":"0"}}} -->
+				<div class="wp-block-buttons ucsc__card-cta"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+					<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button" href="#">Call To Action</a></div>
+					<!-- /wp:button --></div>
+				<!-- /wp:buttons --></div>
+			<!-- /wp:group --></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+			<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image -->
+				<figure class="wp-block-image"><img alt=""/></figure>
+				<!-- /wp:image -->
+
+				<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+				<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Card Title</h3>
+				<!-- /wp:heading -->
+
+				<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+				<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vel ante nec diam placerat vulputate. Fusce ut dui sagittis lacus rutrum tristique ut vitae leo. Phasellus ultrices nunc nec tempus condimentum. Sed facilisis scelerisque lobortis. Suspendisse potenti. Duis iaculis at mi eget porttitor. Donec elementum lacus ut fermentum aliquet.</p>
+				<!-- /wp:paragraph -->
+
+				<!-- wp:buttons {"className":"ucsc__card-cta","style":{"spacing":{"blockGap":"0"}}} -->
+				<div class="wp-block-buttons ucsc__card-cta"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+					<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button" href="#">Call To Action</a></div>
+					<!-- /wp:button --></div>
+				<!-- /wp:buttons --></div>
+			<!-- /wp:group --></div>
+		<!-- /wp:column --></div>
+	<!-- /wp:columns --></div>
+<!-- /wp:group -->

--- a/patterns/card-plain-cta.php
+++ b/patterns/card-plain-cta.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Title: Card w/ CTA
+ * Slug: ucsc-2022/card-plain-cta
+ * Categories: ucsc, cards
+ */
+?>
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain-cta","layout":{"type":"default"}} -->
+<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image {"id":770,"sizeSlug":"sixteen-nine","linkDestination":"none"} -->
+	<figure class="wp-block-image size-sixteen-nine"><img src="https://ucsc.local/wp-content/uploads/2008/06/img_0767-800x496.jpg" alt="Huatulco Coastline" class="wp-image-770"/></figure>
+	<!-- /wp:image -->
+
+	<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+	<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Card Title</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+	<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vel ante nec diam placerat vulputate. Fusce ut dui sagittis lacus rutrum tristique ut vitae leo. Phasellus ultrices nunc nec tempus condimentum. Sed facilisis scelerisque lobortis. Suspendisse potenti. Duis iaculis at mi eget porttitor. Donec elementum lacus ut fermentum aliquet.</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:buttons {"className":"ucsc__card-cta","style":{"spacing":{"blockGap":"0"}}} -->
+	<div class="wp-block-buttons ucsc__card-cta"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+		<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button">Call To Action</a></div>
+		<!-- /wp:button --></div>
+	<!-- /wp:buttons --></div>
+<!-- /wp:group -->

--- a/patterns/card-plain-cta.php
+++ b/patterns/card-plain-cta.php
@@ -7,9 +7,9 @@
  */
 ?>
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain-cta","layout":{"type":"default"}} -->
-<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image {"id":770,"sizeSlug":"sixteen-nine","linkDestination":"none"} -->
-	<figure class="wp-block-image size-sixteen-nine"><img src="https://ucsc.local/wp-content/uploads/2008/06/img_0767-800x496.jpg" alt="Huatulco Coastline" class="wp-image-770"/></figure>
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image -->
+	<figure class="wp-block-image"><img alt=""/></figure>
 	<!-- /wp:image -->
 
 	<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->

--- a/patterns/card-plain-cta.php
+++ b/patterns/card-plain-cta.php
@@ -22,7 +22,7 @@
 
 	<!-- wp:buttons {"className":"ucsc__card-cta","style":{"spacing":{"blockGap":"0"}}} -->
 	<div class="wp-block-buttons ucsc__card-cta"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
-		<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button">Call To Action</a></div>
+		<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button" href="#">Call To Action</a></div>
 		<!-- /wp:button --></div>
 	<!-- /wp:buttons --></div>
 <!-- /wp:group -->

--- a/patterns/card-plain.php
+++ b/patterns/card-plain.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Title: Card
+ * Slug: ucsc-2022/card-plain
+ * Categories: ucsc, cards
+ */
+?>
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
+<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image {"id":770,"sizeSlug":"sixteen-nine","linkDestination":"none"} -->
+	<figure class="wp-block-image size-sixteen-nine"><img src="https://ucsc.local/wp-content/uploads/2008/06/img_0767-800x496.jpg" alt="Huatulco Coastline" class="wp-image-770"/></figure>
+	<!-- /wp:image -->
+
+	<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+	<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Card Title</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
+	<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vel ante nec diam placerat vulputate. Fusce ut dui sagittis lacus rutrum tristique ut vitae leo. Phasellus ultrices nunc nec tempus condimentum. Sed facilisis scelerisque lobortis. Suspendisse potenti. Duis iaculis at mi eget porttitor. Donec elementum lacus ut fermentum aliquet.</p>
+	<!-- /wp:paragraph -->
+<!-- /wp:group -->

--- a/patterns/card-plain.php
+++ b/patterns/card-plain.php
@@ -8,15 +8,15 @@
 ?>
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card-plain","layout":{"type":"default"}} -->
-<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image {"id":770,"sizeSlug":"sixteen-nine","linkDestination":"none"} -->
-	<figure class="wp-block-image size-sixteen-nine"><img src="https://ucsc.local/wp-content/uploads/2008/06/img_0767-800x496.jpg" alt="Huatulco Coastline" class="wp-image-770"/></figure>
+<div class="wp-block-group ucsc__card ucsc__card-plain"><!-- wp:image -->
+	<figure class="wp-block-image"><img alt=""/></figure>
 	<!-- /wp:image -->
 
-	<!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-	<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Card Title</h3>
+	<!-- wp:heading {"level":3} -->
+	<h3 class="wp-block-heading">Card Title</h3>
 	<!-- /wp:heading -->
 
-	<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"base"} -->
-	<p class="has-base-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vel ante nec diam placerat vulputate. Fusce ut dui sagittis lacus rutrum tristique ut vitae leo. Phasellus ultrices nunc nec tempus condimentum. Sed facilisis scelerisque lobortis. Suspendisse potenti. Duis iaculis at mi eget porttitor. Donec elementum lacus ut fermentum aliquet.</p>
-	<!-- /wp:paragraph -->
+	<!-- wp:paragraph {"fontSize":"base"} -->
+	<p class="has-base-font-size">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vel ante nec diam placerat vulputate. Fusce ut dui sagittis lacus rutrum tristique ut vitae leo. Phasellus ultrices nunc nec tempus condimentum. Sed facilisis scelerisque lobortis. Suspendisse potenti. Duis iaculis at mi eget porttitor. Donec elementum lacus ut fermentum aliquet.</p>
+	<!-- /wp:paragraph --></div>
 <!-- /wp:group -->

--- a/patterns/card-yellow.php
+++ b/patterns/card-yellow.php
@@ -23,7 +23,7 @@
 
 		<!-- wp:buttons {"className":"ucsc__card-cta"} -->
 		<div class="wp-block-buttons ucsc__card-cta"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
-			<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button">Call To Action</a></div>
+			<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button" href="#">Call To Action</a></div>
 			<!-- /wp:button --></div>
 		<!-- /wp:buttons --></div>
 	<!-- /wp:group --></div>

--- a/patterns/card-yellow.php
+++ b/patterns/card-yellow.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Title: Card: Yellow w/ CTA
+ * Slug: ucsc-2022/card-yellow-cta
+ * Categories: ucsc, cards
+ */
+?>
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"0","padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"backgroundColor":"ucsc-primary-yellow","className":"ucsc__card ucsc__card-yellow","layout":{"type":"default"}} -->
+<div class="wp-block-group ucsc__card ucsc__card-yellow has-ucsc-primary-yellow-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:image {"id":770,"sizeSlug":"sixteen-nine","linkDestination":"none"} -->
+	<figure class="wp-block-image size-sixteen-nine"><img src="https://ucsc.local/wp-content/uploads/2008/06/img_0767-800x496.jpg" alt="Huatulco Coastline" class="wp-image-770"/></figure>
+	<!-- /wp:image -->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"var:preset|spacing|20","bottom":"var:preset|spacing|40","left":"var:preset|spacing|20"},"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card-inner","layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
+	<div class="wp-block-group ucsc__card-inner" style="padding-top:40px;padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+		<h3 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Card Title</h3>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph {"fontSize":"base"} -->
+		<p class="has-base-font-size">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vel ante nec diam placerat vulputate. Fusce ut dui sagittis lacus rutrum tristique ut vitae leo. </p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:buttons {"className":"ucsc__card-cta"} -->
+		<div class="wp-block-buttons ucsc__card-cta"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+			<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button">Call To Action</a></div>
+			<!-- /wp:button --></div>
+		<!-- /wp:buttons --></div>
+	<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/patterns/card-yellow.php
+++ b/patterns/card-yellow.php
@@ -8,8 +8,8 @@
 ?>
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"0","padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"backgroundColor":"ucsc-primary-yellow","className":"ucsc__card ucsc__card-yellow","layout":{"type":"default"}} -->
-<div class="wp-block-group ucsc__card ucsc__card-yellow has-ucsc-primary-yellow-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:image {"id":770,"sizeSlug":"sixteen-nine","linkDestination":"none"} -->
-	<figure class="wp-block-image size-sixteen-nine"><img src="https://ucsc.local/wp-content/uploads/2008/06/img_0767-800x496.jpg" alt="Huatulco Coastline" class="wp-image-770"/></figure>
+<div class="wp-block-group ucsc__card ucsc__card-yellow has-ucsc-primary-yellow-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:image -->
+	<figure class="wp-block-image"><img alt=""/></figure>
 	<!-- /wp:image -->
 
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"var:preset|spacing|20","bottom":"var:preset|spacing|40","left":"var:preset|spacing|20"},"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card-inner","layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->

--- a/src/scss/block-patterns/_cards.scss
+++ b/src/scss/block-patterns/_cards.scss
@@ -3,8 +3,31 @@
 .ucsc__card {
 	display: flex;
 	flex-flow: column nowrap;
-	align-items: flex-start;
+	align-items: stretch;
 	gap: var(--wp--preset--spacing--20);
+
+	a {
+		color: var(--wp--preset--color--black);
+		font-weight: 700;
+
+		&:hover,
+		&:focus {
+			color: var(--wp--preset--color--ucsc-primary-blue);
+		}
+	}
+
+	&.ucsc__card-yellow {
+
+		a {
+			text-decoration-color: var(--wp--preset--color--black);
+
+			&:hover,
+			&:focus {
+				color: var(--wp--preset--color--ucsc-primary-blue);
+				text-decoration-color: var(--wp--preset--color--ucsc-primary-blue);
+			}
+		}
+	}
 
 	.ucsc__card-grid & {
 		height: 100%;

--- a/src/scss/block-patterns/_cards.scss
+++ b/src/scss/block-patterns/_cards.scss
@@ -1,0 +1,24 @@
+/* BLOCK PATTERN: Cards */
+
+.ucsc__card {
+	display: flex;
+	flex-flow: column nowrap;
+	align-items: flex-start;
+	gap: var(--wp--preset--spacing--20);
+
+	.ucsc__card-grid & {
+		height: 100%;
+	}
+}
+
+.ucsc__card-inner {
+	height: 100%;
+}
+
+.ucsc__card-cta {
+
+	.ucsc__card-grid & {
+		margin-top: auto !important;
+		margin-bottom: 0 !important;
+	}
+}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -38,3 +38,4 @@
 @import "block-patterns/homepage-hero";
 @import "block-patterns/link-list";
 @import "block-patterns/statistics";
+@import "block-patterns/cards";


### PR DESCRIPTION
## What does this do/fix?

- Adds new patterns for 3 types of cards: Plain, Plain w/ CTA, and Yellow background
- Adds two new patterns for card grids. 2 column and 3 column.
- Added stylesheet partial for cards.
- Added new category for card patterns.
- Added new custom image sizes and made them available to the image block in the block editor.

Note that this is the initial pass at the cards and card grids. We can easily expand on this and add more options later. For now, these are the most common use cases presented in the designs.

## QA

Links to relevant issues
- [Link to ticket](https://moderntribe.atlassian.net/browse/UCSC-94)
- [Link to ticket](https://moderntribe.atlassian.net/browse/UCSC-95)
- [Link to ticket](https://moderntribe.atlassian.net/browse/UCSC-79)
- [Link to ticket](https://moderntribe.atlassian.net/browse/UCSC-90)
- [Link to the screencast](https://www.loom.com/share/e14c8c62648b406c9e161b74c19507d0?sid=c59903b4-14e2-441e-8434-986a8d7b070b )

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests
- [ ] No, I need help figuring out how to write the tests.
