### PR TITLE
Feature/ucsc 86/grid with background image

### DIFF
--- a/patterns/grid-with-background-image.php
+++ b/patterns/grid-with-background-image.php
@@ -1,0 +1,95 @@
+<?php
+ /**
+  * Title: 4 columns with background image
+  * Slug: ucsc-2022/grid-with-background-image
+  * Categories: ucsc, columns
+  */
+?>
+
+<!-- wp:cover {"url":"/wp-content/themes/ucsc-2022/images/demo-pattern-tile.png","id":2499,"isRepeated":true,"dimRatio":0,"overlayColor":"ucsc-primary-yellow","minHeight":50,"contentPosition":"center center","align":"full","className":"ucsc-grid-with-background","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-cover alignfull is-repeated ucsc-grid-with-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40);min-height:50px"><span aria-hidden="true" class="wp-block-cover__background has-ucsc-primary-yellow-background-color has-background-dim-0 has-background-dim"></span><div role="img" class="wp-block-cover__image-background wp-image-2499 is-repeated" style="background-position:50% 50%;background-image:url(/wp-content/themes/ucsc-2022/images/demo-pattern-tile.png)"></div><div class="wp-block-cover__inner-container"><!-- wp:group {"className":"ucsc-grid-with-background__wrapper","layout":{"type":"constrained"}} -->
+		<div class="wp-block-group ucsc-grid-with-background__wrapper"><!-- wp:columns {"isStackedOnMobile":false,"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"className":"ucsc-grid-with-background__inner"} -->
+			<div class="wp-block-columns is-not-stacked-on-mobile ucsc-grid-with-background__inner"><!-- wp:column {"className":"ucsc-grid-with-background__sidebar","layout":{"type":"default"}} -->
+				<div class="wp-block-column ucsc-grid-with-background__sidebar"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"backgroundColor":"ucsc-primary-yellow","layout":{"type":"flex","orientation":"vertical"}} -->
+					<div class="wp-block-group has-ucsc-primary-yellow-background-color has-background" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading {"textColor":"ucsc-primary-blue"} -->
+						<h2 class="wp-block-heading has-ucsc-primary-blue-color has-text-color">Sidebar Heading.</h2>
+						<!-- /wp:heading -->
+
+						<!-- wp:paragraph {"textColor":"black"} -->
+						<p class="has-black-color has-text-color">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vel ante nec diam placerat vulputate. Fusce ut dui sagittis lacus rutrum tristique ut vitae leo. Phasellus ultrices nunc nec tempus condimentum.</p>
+						<!-- /wp:paragraph -->
+
+						<!-- wp:buttons -->
+						<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-ucsc-blue"} -->
+							<div class="wp-block-button is-style-ucsc-blue"><a class="wp-block-button__link wp-element-button" href="#">CTA</a></div>
+							<!-- /wp:button --></div>
+						<!-- /wp:buttons --></div>
+					<!-- /wp:group --></div>
+				<!-- /wp:column -->
+
+				<!-- wp:column {"width":"75%","className":"ucsc-grid-with-background__cards"} -->
+				<div class="wp-block-column ucsc-grid-with-background__cards" style="flex-basis:75%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"className":"ucsc-grid-with-background__row","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+					<div class="wp-block-group ucsc-grid-with-background__row"><!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0"}},"backgroundColor":"ucsc-primary-blue","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+						<div class="wp-block-group has-ucsc-primary-blue-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:image {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+							<figure class="wp-block-image"><img alt=""/></figure>
+							<!-- /wp:image -->
+
+							<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","right":"var:preset|spacing|20","left":"var:preset|spacing|20"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontStyle":"normal","fontWeight":"700"}},"textColor":"white","fontSize":"three"} -->
+							<p class="has-white-color has-text-color has-link-color has-three-font-size" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20);font-style:normal;font-weight:700"><a href="#">Column Card Link Example</a></p>
+							<!-- /wp:paragraph --></div>
+						<!-- /wp:group -->
+
+						<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0"}},"backgroundColor":"ucsc-primary-blue","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+						<div class="wp-block-group has-ucsc-primary-blue-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:image {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+							<figure class="wp-block-image"><img alt=""/></figure>
+							<!-- /wp:image -->
+
+							<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","right":"var:preset|spacing|20","left":"var:preset|spacing|20"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontStyle":"normal","fontWeight":"700"}},"textColor":"white","fontSize":"three"} -->
+							<p class="has-white-color has-text-color has-link-color has-three-font-size" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20);font-style:normal;font-weight:700"><a href="#">Column Card Link Example</a></p>
+							<!-- /wp:paragraph --></div>
+						<!-- /wp:group -->
+
+						<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0"}},"backgroundColor":"ucsc-primary-blue","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+						<div class="wp-block-group has-ucsc-primary-blue-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:image {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+							<figure class="wp-block-image"><img alt=""/></figure>
+							<!-- /wp:image -->
+
+							<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","right":"var:preset|spacing|20","left":"var:preset|spacing|20"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontStyle":"normal","fontWeight":"700"}},"textColor":"white","fontSize":"three"} -->
+							<p class="has-white-color has-text-color has-link-color has-three-font-size" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20);font-style:normal;font-weight:700"><a href="#">Column Card Link Example</a></p>
+							<!-- /wp:paragraph --></div>
+						<!-- /wp:group -->
+
+						<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0"}},"backgroundColor":"ucsc-primary-blue","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+						<div class="wp-block-group has-ucsc-primary-blue-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:image {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+							<figure class="wp-block-image"><img alt=""/></figure>
+							<!-- /wp:image -->
+
+							<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","right":"var:preset|spacing|20","left":"var:preset|spacing|20"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontStyle":"normal","fontWeight":"700"}},"textColor":"white","fontSize":"three"} -->
+							<p class="has-white-color has-text-color has-link-color has-three-font-size" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20);font-style:normal;font-weight:700"><a href="#">Column Card Link Example</a></p>
+							<!-- /wp:paragraph --></div>
+						<!-- /wp:group -->
+
+						<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0"}},"backgroundColor":"ucsc-primary-blue","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+						<div class="wp-block-group has-ucsc-primary-blue-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:image {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+							<figure class="wp-block-image"><img alt=""/></figure>
+							<!-- /wp:image -->
+
+							<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","right":"var:preset|spacing|20","left":"var:preset|spacing|20"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontStyle":"normal","fontWeight":"700"}},"textColor":"white","fontSize":"three"} -->
+							<p class="has-white-color has-text-color has-link-color has-three-font-size" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20);font-style:normal;font-weight:700"><a href="#">Column Card Link Example</a></p>
+							<!-- /wp:paragraph --></div>
+						<!-- /wp:group -->
+
+						<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0"}},"backgroundColor":"ucsc-primary-blue","layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+						<div class="wp-block-group has-ucsc-primary-blue-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:image {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+							<figure class="wp-block-image"><img alt=""/></figure>
+							<!-- /wp:image -->
+
+							<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","right":"var:preset|spacing|20","left":"var:preset|spacing|20"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontStyle":"normal","fontWeight":"700"}},"textColor":"white","fontSize":"three"} -->
+							<p class="has-white-color has-text-color has-link-color has-three-font-size" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20);font-style:normal;font-weight:700"><a href="#">Column Card Link Example</a></p>
+							<!-- /wp:paragraph --></div>
+						<!-- /wp:group --></div>
+					<!-- /wp:group --></div>
+				<!-- /wp:column --></div>
+			<!-- /wp:columns --></div>
+		<!-- /wp:group --></div></div>
+<!-- /wp:cover -->

--- a/src/scss/block-patterns/_grid-with-background-image.scss
+++ b/src/scss/block-patterns/_grid-with-background-image.scss
@@ -1,7 +1,7 @@
 /* BLOCK PATTERN: Grid with background image */
 
 .ucsc-grid-with-background__inner {
-	display: grid !important;
+	display: flex !important;
 	grid-template-columns: 1fr;
 
 	@include media-query($wp-columns-unstack) {
@@ -13,11 +13,40 @@
 	display: grid !important;
 	grid-template-columns: 1fr;
 
+	> * {
+		height: 100%;
+	}
+
 	@include media-query($wp-columns-unstack) {
 		grid-template-columns: 1fr 1fr;
 	}
 
 	@include media-query($large) {
 		grid-template-columns: 1fr 1fr 1fr;
+	}
+}
+
+.ucsc-grid-with-background__card {
+	display: grid !important;
+	grid-template-rows: auto 1fr;
+	justify-content: space-between;
+
+	.wp-block-image {
+		overflow: hidden;
+
+		> img {
+			width: 100%;
+		}
+
+		/* CASE: Admin fix for image resizing. */
+		> div {
+			max-width: 100% !important;
+			height: auto !important;
+
+			> img {
+				width: 100%;
+				height: auto;
+			}
+		}
 	}
 }

--- a/src/scss/block-patterns/_grid-with-background-image.scss
+++ b/src/scss/block-patterns/_grid-with-background-image.scss
@@ -1,0 +1,23 @@
+/* BLOCK PATTERN: Grid with background image */
+
+.ucsc-grid-with-background__inner {
+	display: grid !important;
+	grid-template-columns: 1fr;
+
+	@include media-query($wp-columns-unstack) {
+		grid-template-columns: 25% 75%;
+	}
+}
+
+.ucsc-grid-with-background__row {
+	display: grid !important;
+	grid-template-columns: 1fr;
+
+	@include media-query($wp-columns-unstack) {
+		grid-template-columns: 1fr 1fr;
+	}
+
+	@include media-query($large) {
+		grid-template-columns: 1fr 1fr 1fr;
+	}
+}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -45,3 +45,4 @@
 @import "block-patterns/page-header-breadcrumbs";
 @import "block-patterns/cards";
 @import "block-patterns/three-columns-text";
+@import "block-patterns/grid-with-background-image";


### PR DESCRIPTION
## What does this do/fix?

Adds the sidebar + grid/loop pattern to the theme. 
- A default pattern (the same one as the 3col w/ BG image) is applied when you first load the block.
- When replacing that image, use the repeat image option if you have a single tile for a repeatable pattern.
- The sidebar section is in its own column and the 3-column grid is its own column.
  - see the screencast below for the reasoning/approach to this pattern structure.
- When adding images to they cards, use the same image ration on each card. If you mix and match them, the content will not line up properly in the text section.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/UCSC-86)

Screenshots/video:
- [Link to Video](https://www.loom.com/share/73a3dbf4f6c343f6b28568ea444f6a22?sid=46bd537f-279a-48b9-8dcb-f59469d98c0e)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests
- [ ] No, I need help figuring out how to write the tests.
