### PR TITLE
fix: 🐛 Breadcrumbs: appearance and color

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -281,7 +281,7 @@ function ucsc_add_breadcrumbs( $block_content = '', $block = array() ) {
 	if ( ucsc_breadcrumbs_constructor() ) {
 		$breadcrumbs = ucsc_breadcrumbs_constructor();
 	}
-	if ( is_singular() && isset( $breadcrumbs ) && is_page_template( 'page-no-title-with-breadcrumbs' ) ) {
+	if ( is_singular() && isset( $breadcrumbs ) ) {
 		if ( isset( $block['blockName'] ) && 'core/post-title' === $block['blockName'] ) {
 			if ( isset( $block['attrs']['level'] ) ) {
 				$html = str_replace( $block_content, $breadcrumbs . $block_content, $block_content );

--- a/src/scss/components/_breadbrumbs.scss
+++ b/src/scss/components/_breadbrumbs.scss
@@ -21,6 +21,7 @@
 		display: inline-block;
 		margin: 0 0 0.35em;
 		padding-inline-start: 0;
+		margin-block-start: var(--wp--preset--font-size--six);
 	}
 
 	// Individual crumbs.
@@ -36,7 +37,7 @@
 			font-weight: 700;
 			text-transform: uppercase;
 			letter-spacing: 0.04em;
-			color: var(--wp--preset--color--white);
+			color: var(--wp--preset--color--black);
 
 			&:active,
 			&:focus,
@@ -51,11 +52,31 @@
 			content: ">";
 			padding: 0 0.25em;
 			font-size: 0.82rem;
-			color: var(--wp--preset--color--white);
+			color: var(--wp--preset--color--black);
 		}
 
 		&:last-of-type::after {
 			display: none;
 		}
 	}
+}
+
+.page-template-page-no-title-with-breadcrumbs {
+
+	.breadcrumbs {
+
+		&__trail {
+			margin-block-start: 0;
+		}
+
+		&__crumb {
+
+			a,
+			&::after {
+				color: var(--wp--preset--color--white);
+			}
+		}
+
+	}
+
 }


### PR DESCRIPTION
## What does this do/fix?

- Set crumbs to be conditionally white or black based on page template.
- Set spacing above crumbs so the title is not smashed against the header.

## QA

- Check breadcrumbs appear when you add the page header pattern that contains breadcrumbs to a page with the 'no-title-with-breadcrumbs' template.
- Check that breadcrumbs also appear when you create a basic page one or more levels deep from the home page.