### PR TITLE
fix: 🐛 Set anchor link scroll position below fixed site header height

### DIFF
--- a/src/scss/elements/_links.scss
+++ b/src/scss/elements/_links.scss
@@ -34,3 +34,30 @@ a {
 		}
 	}
 }
+
+// Clicking anchor links should
+// have padding to account for
+// the fixed header height
+:target {
+	scroll-margin-top: 5rem;
+	animation: 2s ease-out 0.1s bgcolor;
+
+	@keyframes bgcolor {
+
+		from {
+			background-color: initial;
+		}
+
+		15% {
+			background-color: var(--wp--preset--color--ucsc-primary-yellow);
+		}
+
+		to {
+			background-color: initial;
+		}
+	}
+
+	@include media-query($wp-columns-unstack) {
+		scroll-margin-top: 11rem;
+	}
+}


### PR DESCRIPTION
## What does this do/fix?

- Set anchor link scroll position below fixed site header height. 
- Adds a momentary background-color to indicate the anchor target
