### PR TITLE
[UCSC-130] Prevent sticky header from covering scroll targets

### DIFF
--- a/src/js/components/main-nav.js
+++ b/src/js/components/main-nav.js
@@ -267,7 +267,7 @@ const deactivateMenuItem = ( data ) => {
 
 const handleResize = () => {
 	// Find the site header height.
-	const siteHeader = document.querySelector( '.site-header__header' );
+	const siteHeader = document.querySelector( '.site-header' );
 	document.documentElement.style.setProperty(
 		'--site-header-height',
 		siteHeader.clientHeight + 'px'

--- a/src/scss/theme-regions/_site-header.scss
+++ b/src/scss/theme-regions/_site-header.scss
@@ -51,6 +51,13 @@
 	}
 }
 
+// Add a top scroll margin to scroll targets in other regions so they're not
+// behind the sticky nav after being scrolled to.
+.content-region *,
+.footer-region * {
+	scroll-margin-top: calc(var(--site-header-height, 0) + 1rem);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Site Header Template
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What does this do/fix?

Adds a scroll margin based on the sticky header height so scroll targets/anchors in other regions aren't behind the sticky nav after being scrolled to.

Note that this and everything else to do with the sticky nav should be tested with a non-admin or unauthenticated session, as the WP admin bar screws with all of the height and positioning calculations.

## QA

Links to relevant issues
- https://moderntribe.atlassian.net/browse/UCSC-130
