### PR TITLE
fix: :bug: Correct issue of images breaking out of content area

### DIFF
--- a/src/scss/base/_alignments.scss
+++ b/src/scss/base/_alignments.scss
@@ -1,18 +1,14 @@
 /*--------------------------------------------------------------
 # - Alignments
 --------------------------------------------------------------*/
-.alignleft {
-	float: left;
-	clear: left;
+
+/*
+ * Fix WP bug that pushes left and rigtht floats outside bounding box
+ */
+.is-layout-constrained > .alignleft {
+	margin-left: calc((100% - var(--wp--style--global--content-size)) / 2) !important;
 }
 
-.alignright {
-	float: right;
-	clear: right;
+.is-layout-constrained > .alignright {
+	margin-right: calc((100% - var(--wp--style--global--content-size)) / 2) !important;
 }
-
-.aligncenter {
-	clear: both;
-	display: table;
-}
-

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -8,6 +8,7 @@
 @import "base/normalize";
 @import "base/svg";
 @import "base/layout";
+@import "base/alignments";
 
 // Theme
 //===============================

--- a/wp-blocks/image.css
+++ b/wp-blocks/image.css
@@ -4,10 +4,3 @@
 	color: var(--ucsc-dark-gray);
 }
 
-body .is-layout-constrained > .alignleft {
-	margin-left: calc((100% - var(--wp--style--global--content-size)) / 2) !important;
-}
-
-body .is-layout-constrained > .alignright {
-	margin-right: calc((100% - var(--wp--style--global--content-size)) / 2) !important;
-}

--- a/wp-blocks/image.css
+++ b/wp-blocks/image.css
@@ -3,3 +3,11 @@
 	font-size: var(--wp--preset--font-size--small);
 	color: var(--ucsc-dark-gray);
 }
+
+body .is-layout-constrained > .alignleft {
+	margin-left: calc((100% - var(--wp--style--global--content-size)) / 2) !important;
+}
+
+body .is-layout-constrained > .alignright {
+	margin-right: calc((100% - var(--wp--style--global--content-size)) / 2) !important;
+}


### PR DESCRIPTION
## What does this do/fix?

Fixes #257, which describes a 🐛 wherein images that are aligned left or right (floated) break out of their binding box 

## QA

Links to relevant issues
- [UCSC's discussion](https://github.com/ucsc/ucsc-2022/issues/257)
- [Gutenberg discussion](https://github.com/WordPress/gutenberg/issues/37504)

Links to deployed, scaffolded demo:
N/A

Screenshots/video:

Before
![bad-alignment](https://github.com/ucsc/ucsc-2022/assets/1000543/5b24ba3f-d7b6-4a6e-a322-891c3f3dd605)

After
![good-alignment](https://github.com/ucsc/ucsc-2022/assets/1000543/fb7448b8-93fe-45dc-ae64-831cd74d6880)

Again
![good2-alignment](https://github.com/ucsc/ucsc-2022/assets/1000543/19e98c65-2b20-45be-9605-6ff432bfa996)



## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because it's a style change.
- [ ] No, I need help figuring out how to write the tests.
