### PR TITLE
feat: ✨ Make Google site search the default

### DIFF
--- a/src/scss/theme-regions/_site-content.scss
+++ b/src/scss/theme-regions/_site-content.scss
@@ -2,3 +2,8 @@
 main.wp-block-group {
 	margin-block-start: 0 !important;
 }
+
+/* Remove default padding from Google site search results */
+.gsc-control-cse {
+	padding: 0 !important;
+}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,14 +1,18 @@
 <!-- wp:template-part {"slug":"header","theme":"ucsc-2022","tagName":"header","className":"header-region"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}},"className":"content-region","layout":{"inherit":true}} -->
-<main class="wp-block-group content-region" style="margin-top:var(--wp--preset--spacing--50)">
+<!-- wp:group {"tagName":"main","className":"content-region"} -->
+<main class="wp-block-group content-region">
+	<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--40)">
+		<!-- wp:group {"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group"><!-- wp:query-title {"type":"search","className":"primary-post-title"} /--></div>
+		<!-- /wp:group -->
 
-	<!-- wp:heading {"level":1} -->
-	<h1>Search results</h1>
-	<!-- /wp:heading -->
-
-	<!-- wp:template-part {"slug":"post-query", "className":"search-query"} /-->
-
+		<!-- wp:shortcode -->
+		[site-search]
+		<!-- /wp:shortcode -->
+	</div>
+	<!-- /wp:group -->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## What does this do/fix?

Adds Google site search to the search results page template, and removes default padding from the search results area. 

## QA

Links to relevant issues
- [Issues #40](https://github.com/ucsc/ucsc-2022/issues/40)

Links to deployed, scaffolded demo:
- [Example search results](https://wordpress-dev.ucsc.edu/?s=wordpress)
