### PR TITLE
Fix/regen block pattern from wrong wp version

### DIFF
--- a/parts/post-query.html
+++ b/parts/post-query.html
@@ -3,9 +3,9 @@
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card\u002d\u002dquery-loop","layout":{"type":"default"}} -->
 	<div class="wp-block-group ucsc__card ucsc__card--query-loop" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-featured-image {"isLink":true,"width":"","height":"","sizeSlug":"sixteen-nine","className":"ucsc-query-loop__image"} /-->
 	
-	<!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|ucsc-royal-blue"}}},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"textColor":"black","className":"ucsc-query-loop__category","fontSize":"small"} /-->
+	<!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|ucsc-secondary-blue"}}},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"textColor":"black","className":"ucsc-query-loop__category","fontSize":"small"} /-->
 	
-	<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","right":"0","left":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|ucsc-royal-blue"}}}},"textColor":"black","fontSize":"three"} /-->
+	<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","right":"0","left":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|ucsc-secondary-blue"}}}},"textColor":"black","fontSize":"three"} /-->
 	
 	<!-- wp:post-date {"style":{"spacing":{"margin":{"bottom":"0","top":"0","right":"0","left":"0"}}},"textColor":"black","className":"ucsc-query-loop__post-date","fontSize":"base"} /-->
 	

--- a/parts/post-query.html
+++ b/parts/post-query.html
@@ -1,23 +1,23 @@
 <!-- wp:query {"queryId":0,"query":{"perPage":12,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"flex","columns":3},"className":"ucsc__post-query-loop","layout":{"type":"constrained"}} -->
 <main class="wp-block-query ucsc__post-query-loop"><!-- wp:post-template -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card\u002d\u002dquery-loop","layout":{"type":"default"}} -->
-<div class="wp-block-group ucsc__card ucsc__card--query-loop" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-featured-image {"isLink":true,"width":"","height":"","sizeSlug":"sixteen-nine","className":"ucsc-query-loop__image"} /-->
-
-<!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|ucsc-royal-blue"}}}},"textColor":"black","className":"ucsc-query-loop__category","fontSize":"small"} /-->
-
-<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","right":"0","left":"0","bottom":"var:preset|spacing|20"}},"elements":{"link":{"color":{"text":"var:preset|color|ucsc-royal-blue"}}}},"textColor":"black","fontSize":"three"} /-->
-
-<!-- wp:post-date {"style":{"spacing":{"margin":{"bottom":"0"}}},"textColor":"black","className":"ucsc-query-loop__post-date","fontSize":"base"} /-->
-
-<!-- wp:post-excerpt {"className":"ucsc-query-loop__excerpt"} /--></div>
-<!-- /wp:group -->
-<!-- /wp:post-template -->
-
-<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-<!-- wp:query-pagination-previous /-->
-
-<!-- wp:query-pagination-numbers /-->
-
-<!-- wp:query-pagination-next /-->
-<!-- /wp:query-pagination --></main>
-<!-- /wp:query -->
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card\u002d\u002dquery-loop","layout":{"type":"default"}} -->
+	<div class="wp-block-group ucsc__card ucsc__card--query-loop" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-featured-image {"isLink":true,"width":"","height":"","sizeSlug":"sixteen-nine","className":"ucsc-query-loop__image"} /-->
+	
+	<!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|ucsc-royal-blue"}}},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"textColor":"black","className":"ucsc-query-loop__category","fontSize":"small"} /-->
+	
+	<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","right":"0","left":"0","bottom":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|ucsc-royal-blue"}}}},"textColor":"black","fontSize":"three"} /-->
+	
+	<!-- wp:post-date {"style":{"spacing":{"margin":{"bottom":"0","top":"0","right":"0","left":"0"}}},"textColor":"black","className":"ucsc-query-loop__post-date","fontSize":"base"} /-->
+	
+	<!-- wp:post-excerpt {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"ucsc-query-loop__excerpt"} /--></div>
+	<!-- /wp:group -->
+	<!-- /wp:post-template -->
+	
+	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<!-- wp:query-pagination-previous /-->
+	
+	<!-- wp:query-pagination-numbers /-->
+	
+	<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination --></main>
+	<!-- /wp:query -->

--- a/parts/post-query.html
+++ b/parts/post-query.html
@@ -1,23 +1,23 @@
-<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","className":"ucsc__post-query-loop","layout":{"type":"constrained"}} -->
-<main class="wp-block-query ucsc__post-query-loop"><!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"className":"ucsc__card ucsc__card\u002d\u002dquery-loop","layout":{"type":"default"}} -->
-	<div class="wp-block-group ucsc__card ucsc__card--query-loop" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-featured-image {"isLink":true,"width":"","height":"","sizeSlug":"sixteen-nine","className":"ucsc-query-loop__image"} /-->
-	
-	<!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|ucsc-secondary-blue"},":hover":{"color":{"text":"var:preset|color|ucsc-primary-blue"}}}}},"textColor":"black","className":"ucsc-query-loop__category","fontSize":"small"} /-->
-	
-	<!-- wp:post-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|ucsc-secondary-blue"},":hover":{"color":{"text":"var:preset|color|ucsc-primary-blue"}}}}},"fontSize":"three"} /-->
-	
-	<!-- wp:post-date {"style":{"spacing":{"margin":{"bottom":"0"}}},"textColor":"black","className":"ucsc-query-loop__post-date","fontSize":"base"} /-->
-	
-	<!-- wp:post-excerpt {"className":"ucsc-query-loop__excerpt"} /--></div>
-	<!-- /wp:group -->
-	<!-- /wp:post-template -->
-	
-	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-	<!-- wp:query-pagination-previous /-->
-	
-	<!-- wp:query-pagination-numbers /-->
-	
-	<!-- wp:query-pagination-next /-->
-	<!-- /wp:query-pagination --></main>
-	<!-- /wp:query -->
+<!-- wp:query {"queryId":0,"query":{"perPage":12,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"flex","columns":3},"className":"ucsc__post-query-loop","layout":{"type":"constrained"}} -->
+<main class="wp-block-query ucsc__post-query-loop"><!-- wp:post-template -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"blockGap":"var:preset|spacing|20"}},"className":"ucsc__card ucsc__card\u002d\u002dquery-loop","layout":{"type":"default"}} -->
+<div class="wp-block-group ucsc__card ucsc__card--query-loop" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:post-featured-image {"isLink":true,"width":"","height":"","sizeSlug":"sixteen-nine","className":"ucsc-query-loop__image"} /-->
+
+<!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|ucsc-royal-blue"}}}},"textColor":"black","className":"ucsc-query-loop__category","fontSize":"small"} /-->
+
+<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","right":"0","left":"0","bottom":"var:preset|spacing|20"}},"elements":{"link":{"color":{"text":"var:preset|color|ucsc-royal-blue"}}}},"textColor":"black","fontSize":"three"} /-->
+
+<!-- wp:post-date {"style":{"spacing":{"margin":{"bottom":"0"}}},"textColor":"black","className":"ucsc-query-loop__post-date","fontSize":"base"} /-->
+
+<!-- wp:post-excerpt {"className":"ucsc-query-loop__excerpt"} /--></div>
+<!-- /wp:group -->
+<!-- /wp:post-template -->
+
+<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination --></main>
+<!-- /wp:query -->


### PR DESCRIPTION
## What does this do/fix?

Regenerated template part for `post-query` from the proper WP version 6.2.2. Previous version of this file was generated with 6.3.x, and was incompatible.

Two notes:
- The query page size was set back to 12, which was inadvertently set to 10 in the previous version.
- 6.2.x doesn't let the editor select an explicit link hover color, so you'll see that config disappear in this PR.

## QA

Links to relevant issues
- https://moderntribe.atlassian.net/browse/UCSC-131