### PR TITLE
Added heading default margin.

### DIFF
--- a/src/scss/block-patterns/_sidebar-with-navigation.scss
+++ b/src/scss/block-patterns/_sidebar-with-navigation.scss
@@ -7,6 +7,13 @@
 		flex-direction: row;
 	}
 
+	h2,
+	h3,
+	h4,
+	h5 {
+		margin-bottom: 8px;
+	}
+
 	// Block
 	.wp-block-navigation {
 		margin-top: 0;


### PR DESCRIPTION
## What does this do/fix?

Adds a default bottom margin for sidebar headings for WP 6.2.x compatibility (previously worked on 6.3.x). This can still be overridden by the block editor's explicit styles, if any are set.

## QA

Links to relevant issues
- https://moderntribe.atlassian.net/browse/UCSC-134