### PR TITLE
Fix/side nav toggle button a11y qa rem

### DIFF
--- a/src/js/block-patterns/sidebar-with-navigation.js
+++ b/src/js/block-patterns/sidebar-with-navigation.js
@@ -27,9 +27,8 @@ const toggleSubmenu = ( toggle ) => {
 			.forEach( ( subItemLink ) => {
 				subItemLink.setAttribute( 'tabIndex', -1 );
 			} );
-	}
-	// Show
-	else {
+		// Show
+	} else {
 		item.classList.add( selectors.itemExpandedClass );
 		submenu.setAttribute( 'aria-hidden', false );
 		submenu
@@ -58,7 +57,7 @@ const fixAriaAttributes = () => {
 
 			const submenu = item.querySelector( selectors.submenuSelector );
 			if ( submenu ) {
-				toggle.setAttribute( 'aria-hidden', ! isExpanded );
+				submenu.setAttribute( 'aria-hidden', ! isExpanded );
 			}
 		} );
 	} );


### PR DESCRIPTION
## What does this do/fix?

Fixes an a11y issue with the Sidebar Menu block pattern where an `aria-hidden` attribute was accidentally being applied to a the submenu toggle buttons instead of the hidden submenu menus. This was a copy/paste error initially.

## QA

Links to relevant issues
- https://moderntribe.atlassian.net/browse/UCSC-134