### PR TITLE
fix: 🐛 Don't show breadcrumbs on a post-title block that is set to be H2 or lower

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -281,7 +281,7 @@ function ucsc_add_breadcrumbs( $block_content = '', $block = array() ) {
 	}
 	if ( !is_page_template( 'page-no-title' ) && isset( $breadcrumbs ) ) {
 		if ( isset( $block['blockName'] ) && 'core/post-title' === $block['blockName'] ) {
-			if ( $block['attrs']['level'] === 1 ) {
+			if ( isset($block['attrs']['level']) && $block['attrs']['level'] === 1 ) {
 				$html = str_replace( $block_content, $breadcrumbs . $block_content, $block_content );
 				return $html;
 			}

--- a/functions.php
+++ b/functions.php
@@ -281,7 +281,7 @@ function ucsc_add_breadcrumbs( $block_content = '', $block = array() ) {
 	}
 	if ( !is_page_template( 'page-no-title' ) && isset( $breadcrumbs ) ) {
 		if ( isset( $block['blockName'] ) && 'core/post-title' === $block['blockName'] ) {
-			if ( isset( $block['attrs']['level'] ) ) {
+			if ( $block['attrs']['level'] === 1 ) {
 				$html = str_replace( $block_content, $breadcrumbs . $block_content, $block_content );
 				return $html;
 			}


### PR DESCRIPTION
## What does this do/fix?

Don't show breadcrumbs on a post-title block that is set to be H2 or lower

Fixes #280

Links to relevant issues
- [Post title block shows breadcrumbs in all instances](https://github.com/ucsc/ucsc-2022/issues/280)
