### PR TITLE
First level of integration with CoAuthors Plus plugin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -196,7 +196,7 @@ add_filter( 'render_block', 'ucsc_adjust_structure', 10, 2 );
  */
 function ucsc_post_author_link( $block_content = '', $block = array() ) {
 	// Check for single post; use `global $post` to access data outide the Loop.
-	if ( is_single() ) {
+	if ( is_singular()  ) {
 		if ( isset( $block['blockName'] ) && 'core/post-author' === $block['blockName'] ) {
 			if ( function_exists( 'coauthors_posts_links' ) ) {
     		$block_content = coauthors_posts_links( null, null, null, null, false );
@@ -251,7 +251,7 @@ function ucsc_breadcrumbs_constructor() {
 		'labels'         => $labels,
 		'show_on_front'  => true,
 		'show_trail_end' => false,
-		'container_class'=> 'ucsc-page-header__breadcrumbs alignwide'
+		'container_class'=> 'ucsc-page-header__breadcrumbs'
 	);
 	return Hybrid\Breadcrumbs\Trail::render( $args );
 }

--- a/functions.php
+++ b/functions.php
@@ -202,6 +202,11 @@ function ucsc_post_author_link( $block_content = '', $block = array() ) {
     		$block_content = coauthors_posts_links( null, null, null, null, false );
 			}
 		}
+		if ( isset( $block['blockName'] ) && 'core/post-author-name' === $block['blockName'] ) {
+			if ( function_exists( 'coauthors' ) ) {
+				$block_content = coauthors( null, null, null, null, false );
+			}
+		}
 	}
 	return $block_content;
 }

--- a/functions.php
+++ b/functions.php
@@ -197,14 +197,9 @@ add_filter( 'render_block', 'ucsc_adjust_structure', 10, 2 );
 function ucsc_post_author_link( $block_content = '', $block = array() ) {
 	// Check for single post; use `global $post` to access data outide the Loop.
 	if ( is_singular()  ) {
-		if ( isset( $block['blockName'] ) && 'core/post-author' === $block['blockName'] ) {
-			if ( function_exists( 'coauthors_posts_links' ) ) {
-    		$block_content = coauthors_posts_links( null, null, null, null, false );
-			}
-		}
 		if ( isset( $block['blockName'] ) && 'core/post-author-name' === $block['blockName'] ) {
-			if ( function_exists( 'coauthors' ) ) {
-				$block_content = coauthors( null, null, null, null, false );
+			if ( function_exists( 'coauthors_posts_links' ) ) {
+				$block_content = coauthors_posts_links( null, null, null, null, false );
 			}
 		}
 	}

--- a/templates/single.html
+++ b/templates/single.html
@@ -9,7 +9,7 @@
 		<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group"
 			style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
-			<!-- wp:post-author {"showAvatar":false,"showBio":false,"style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} /-->
+			<!-- wp:post-author-name /-->
 		</div>
 		<!-- /wp:group -->
 	</div>


### PR DESCRIPTION
## What does this do/fix?

1. The "author name" block is filtered to add guest authors when the the CoAuthors Plus plugin is turned on and guest authors are added to a post. 
2. The "single" template is updated to switch from the "author" block to the "author name" block, which is more minimal in settings.

Note: some "author name" UI settings will not work when Coauthors Plus is turned on.

Other post author blocks ("author" and "author biography") will be integrated later

## QA

Links to relevant issues
- [#287](https://github.com/ucsc/ucsc-2022/issues/287)
- [#284](https://github.com/ucsc/ucsc-2022/issues/284)

Screenshots/video:
- [video explanation](https://share.cleanshot.com/25dQg21b6GcG4lXbKKZ0)