### PR TITLE
fix: 🐛 Contrast error with date in query loop block  Fixes #282

### DIFF
--- a/templates/single.html
+++ b/templates/single.html
@@ -4,7 +4,7 @@
 <main class="wp-block-group content-region"><!-- wp:group {"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group"><!-- wp:post-title {"level":1,"className":"primary-post-title"} /-->
 
-		<!-- wp:post-date {"style":{"elements":{"link":{"color":{"text":"var:preset|color|black"}}}},"textColor":"black"} /-->
+		<!-- wp:post-date {"style":{"elements":{"link":{"color":{"text":"var:preset|color|dark-gray"},":hover":{"color":{"text":"var:preset|color|ucsc-secondary-blue"}}}},"spacing":{"margin":{"top":"1em","bottom":"0.5em"}}},"textColor":"dark-gray","fontSize":"small"} /-->
 
 		<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":"0"}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group"

--- a/theme.json
+++ b/theme.json
@@ -47,6 +47,11 @@
 					"slug": "black"
 				},
 				{
+					"name": "Dark Gray",
+					"color": "#595959",
+					"slug": "dark-gray"
+				},
+				{
 					"name": "Light Gray",
 					"color": "#d9d9d9",
 					"slug": "light-gray"
@@ -346,7 +351,7 @@
 				}
 			},
 			"core/navigation": {
-			    "maxNestingLevel": 1,
+				"maxNestingLevel": 1,
 				"typography": {
 					"customFontSize": false
 				},
@@ -384,8 +389,7 @@
 				"radius": "0"
 			},
 			"color": {
-				"link": "var(--wp--preset--color--ucsc-primary-blue)",
-				"link-decoration": "var(--wp--preset--color--ucsc-primary-yellow)"
+				"link": "var(--wp--preset--color--ucsc-primary-blue)"
 			}
 		}
 	},
@@ -485,23 +489,6 @@
 				},
 				"spacing": {
 					"blockGap": "var(--wp--preset--spacing--40)"
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)",
-					"lineHeight": "var(--wp--custom--line-height--small)"
-				},
-				"color": {
-					"text": "var(--wp--preset--color--light-gray)"
-				},
-				"spacing": {
-					"margin": {
-						"top": "0",
-						"right": "0",
-						"bottom": "0.555em",
-						"left": "0"
-					}
 				}
 			},
 			"core/post-title": {


### PR DESCRIPTION
## What does this do/fix?

- Removed the post-date block definition from theme.json. These can be configured in templates from now on
- Added a "dark-gray" color option so there are more options between light gray and black.

Links to relevant issues
- [#282](https://github.com/ucsc/ucsc-2022/issues/282)
