### PR TITLE
set submenu to open if we're on the active page.

### DIFF
--- a/src/js/block-patterns/sidebar-with-navigation.js
+++ b/src/js/block-patterns/sidebar-with-navigation.js
@@ -121,7 +121,24 @@ const initBlockMarkup = () => {
 				toggle.remove();
 				nestedSubmenu.remove();
 			} );
+
+		initBlockOnPageLoad( block );
 	} );
+};
+
+const initBlockOnPageLoad = ( block ) => {
+	if ( ! block ) {
+		return;
+	}
+
+	const currentItem = block.querySelector( '.current-menu-item' );
+
+	if ( ! currentItem ) {
+		return;
+	}
+
+	const submenu = currentItem.closest( 'li.wp-block-navigation-submenu' );
+	toggleSubmenu( submenu.querySelector( selectors.toggleSelector ) );
 };
 
 /**
@@ -133,6 +150,7 @@ const init = () => {
 	}
 
 	initBlockMarkup();
+	initBlockOnPageLoad();
 	bindEvents();
 	fixAriaAttributes();
 };


### PR DESCRIPTION
## What does this do/fix?

When we on a current page that is within a submenu or has a submenu, open the submenu by default.

## QA

Links to relevant issues
- [Link to Issue](https://moderntribe.atlassian.net/browse/UCSC-147)

Screenshots/video:
- [Link to Video](https://www.loom.com/share/c10802aeea8c4ec5b0b13d14399df71f?sid=943e731f-b945-43b2-bb3d-e418f70015cd)

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests
- [ ] No, I need help figuring out how to write the tests.
