### PR TITLE
💄 Style inline `<code>` element.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'ucsc_setup' ) ) :
 		/*
 		* Load additional Core block styles.
 		*/
-		$styled_blocks = array( 'core/button', 'core/columns', 'core/post-template', 'core/post-author', 'core/site-title', 'core/query-pagination', 'core/post-content', 'core/rss', 'core/post-title', 'core/post-comments', 'core/navigation', 'core/list', 'core/separator', 'core/latest-posts', 'core/quote', 'core/image', 'core/search', 'core/paragraph','core/code','ucscblocks/accordion' );
+		$styled_blocks = array( 'core/button', 'core/columns', 'core/post-template', 'core/post-author', 'core/site-title', 'core/query-pagination', 'core/post-content', 'core/rss', 'core/post-title', 'core/post-comments', 'core/navigation', 'core/list', 'core/separator', 'core/latest-posts', 'core/quote', 'core/image', 'core/search', 'core/paragraph', 'ucscblocks/accordion' );
 		foreach ( $styled_blocks as $block ) {
 
 			$name = explode('/', $block);
@@ -82,7 +82,6 @@ function ucsc_scripts() {
 	wp_enqueue_style( 'ucsc-styles-scss', get_template_directory_uri() . '/build/style-index.css', array(), wp_get_theme()->get( 'Version' ) );
 	wp_enqueue_style( 'ucsc-google-roboto-font', 'https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,600,700,800&display=swap', false );
 	wp_enqueue_style( 'ucsc-google-roboto-serif-font', 'https://fonts.googleapis.com/css2?family=Roboto+Serif:ital,opsz,wght@0,8..144,400;0,8..144,500;0,8..144,600;1,8..144,400;1,8..144,500;1,8..144,600&display=swap', false );
-	wp_enqueue_style( 'ucsc-google-roboto-mono-font', 'https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap', false );
 	wp_register_script( 'ucsc-front', get_template_directory_uri() . '/build/theme.js', array(), wp_get_theme()->get( 'Version' ), true );
 	wp_enqueue_script( 'ucsc-front' );
 

--- a/functions.php
+++ b/functions.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'ucsc_setup' ) ) :
 		/*
 		* Load additional Core block styles.
 		*/
-		$styled_blocks = array( 'core/button', 'core/columns', 'core/post-template', 'core/post-author', 'core/site-title', 'core/query-pagination', 'core/post-content', 'core/rss', 'core/post-title', 'core/post-comments', 'core/navigation', 'core/list', 'core/separator', 'core/latest-posts', 'core/quote', 'core/image', 'core/search', 'core/paragraph','ucscblocks/accordion' );
+		$styled_blocks = array( 'core/button', 'core/columns', 'core/post-template', 'core/post-author', 'core/site-title', 'core/query-pagination', 'core/post-content', 'core/rss', 'core/post-title', 'core/post-comments', 'core/navigation', 'core/list', 'core/separator', 'core/latest-posts', 'core/quote', 'core/image', 'core/search', 'core/paragraph','core/code','ucscblocks/accordion' );
 		foreach ( $styled_blocks as $block ) {
 
 			$name = explode('/', $block);
@@ -82,6 +82,7 @@ function ucsc_scripts() {
 	wp_enqueue_style( 'ucsc-styles-scss', get_template_directory_uri() . '/build/style-index.css', array(), wp_get_theme()->get( 'Version' ) );
 	wp_enqueue_style( 'ucsc-google-roboto-font', 'https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,600,700,800&display=swap', false );
 	wp_enqueue_style( 'ucsc-google-roboto-serif-font', 'https://fonts.googleapis.com/css2?family=Roboto+Serif:ital,opsz,wght@0,8..144,400;0,8..144,500;0,8..144,600;1,8..144,400;1,8..144,500;1,8..144,600&display=swap', false );
+	wp_enqueue_style( 'ucsc-google-roboto-mono-font', 'https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap', false );
 	wp_register_script( 'ucsc-front', get_template_directory_uri() . '/build/theme.js', array(), wp_get_theme()->get( 'Version' ), true );
 	wp_enqueue_script( 'ucsc-front' );
 

--- a/src/scss/elements/_code.scss
+++ b/src/scss/elements/_code.scss
@@ -1,0 +1,7 @@
+:not(pre) > code {
+	background-color: #eef;
+	border: 1px solid #d9d9d9;
+	border-radius: 3px;
+	padding: 1px 5px;
+}
+

--- a/src/scss/elements/_code.scss
+++ b/src/scss/elements/_code.scss
@@ -1,7 +1,5 @@
 :not(pre) > code {
-	background-color: #eef;
-	border: 1px solid #d9d9d9;
-	border-radius: 3px;
-	padding: 1px 5px;
+	background-color: #fff3c5;
+	padding: 0.0625em 0.3125em;
 }
 

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -17,6 +17,7 @@
 // Elements
 //===============================
 @import "elements/links";
+@import "elements/code";
 
 // Pages
 //===============================

--- a/wp-blocks/code.css
+++ b/wp-blocks/code.css
@@ -1,4 +1,0 @@
-.wp-block-code {
-	font-family: "Roboto Mono", Menlo, Consolas, monaco, monospace !important;
-	font-weight: 400;
-}

--- a/wp-blocks/code.css
+++ b/wp-blocks/code.css
@@ -1,0 +1,4 @@
+.wp-block-code {
+	font-family: "Roboto Mono", Menlo, Consolas, monaco, monospace !important;
+	font-weight: 400;
+}


### PR DESCRIPTION
Style the inline version of the `<code>` tag. Copied styles from Markdown. #173

## What does this do/fix?

Styles the inline `<code>` element. If this element is nested within a `<pre>` element, no styling is applied. This only applies to the inline element itself. Fixes #173 

## QA

Links to relevant issues
- #173

Screenshots/video:
- ![code-element](https://github.com/ucsc/ucsc-2022/assets/1000543/1cd8a4af-0888-4698-aab7-177153f68c7d)

## Tests

Does this have tests?

- [x] Yes, see screenshot
