### PR TITLE
💄 Style Details Block separately from Accordion Block

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'ucsc_setup' ) ) :
 		/*
 		* Load additional Core block styles.
 		*/
-		$styled_blocks = array( 'core/button', 'core/columns', 'core/post-template', 'core/post-author', 'core/site-title', 'core/query-pagination', 'core/post-content', 'core/rss', 'core/post-title', 'core/post-comments', 'core/navigation', 'core/list', 'core/separator', 'core/latest-posts', 'core/quote', 'core/image', 'core/search', 'core/paragraph', 'ucscblocks/accordion' );
+		$styled_blocks = array( 'core/button', 'core/columns', 'core/post-template', 'core/post-author', 'core/site-title', 'core/query-pagination', 'core/post-content', 'core/rss', 'core/post-title', 'core/post-comments', 'core/navigation', 'core/list', 'core/separator', 'core/latest-posts', 'core/quote', 'core/image', 'core/search', 'core/paragraph', 'ucscblocks/accordion', 'core/details' );
 		foreach ( $styled_blocks as $block ) {
 
 			$name = explode('/', $block);

--- a/wp-blocks/accordion.css
+++ b/wp-blocks/accordion.css
@@ -1,9 +1,7 @@
-details,
 .ucsc-block-accordion {
 	position: relative;
 }
 
-details summary,
 .ucsc-block-accordion summary {
 	box-sizing: border-box;
 	width: 100%;
@@ -14,12 +12,10 @@ details summary,
 	transition: font-weight 0.2s ease-in-out;
 }
 
-details summary::-webkit-.ucsc-block-accordion-marker,
 .ucsc-block-accordion summary::-webkit-.ucsc-block-accordion-marker {
 	display: none;
 }
 
-details summary::before,
 .ucsc-block-accordion summary::before {
 	content: "";
 	position: absolute;
@@ -30,22 +26,18 @@ details summary::before,
 	transition: transform 0.1s linear;
 }
 
-details[open] > summary,
 .ucsc-block-accordion[open] > summary {
 	color: var(--wp--preset--color--ucsc-primary-blue);
 	font-weight: 600;
 	border-bottom: 1px solid var(--wp--preset--color--ucsc-primary-yellow);
 }
 
-details summary:focus,
-details summary:hover,
 .ucsc-block-accordion summary:focus,
 .ucsc-block-accordion summary:hover {
 	outline: none;
 	color: var(--wp--preset--color--ucsc-primary-blue);
 }
 
-details[open] summary::before,
 .ucsc-block-accordion[open] summary::before {
 	transform: rotate(90deg);
 }

--- a/wp-blocks/details.css
+++ b/wp-blocks/details.css
@@ -1,16 +1,3 @@
-.wp-block-details {
-	box-sizing: border-box;
-	overflow: hidden;
-}
-
-.wp-block-details summary {
-	cursor: pointer;
-}
-
-.wp-block-details.is-style-default summary {
-	padding-left: 0.5rem;
-}
-
 .wp-block-details.is-style-chevron summary::before {
 	content: "\f345";
 }
@@ -25,17 +12,6 @@
 
 .wp-block-details summary > * {
 	display: inline;
-}
-
-/* Use block gap for block; falls back to browser default if not supported. */
-.wp-block-details > *:not(summary) {
-	margin-block-start: 0;
-	margin-block-end: 0;
-}
-
-/* Remove excess margin from the last block. */
-.wp-block-details > *:last-child {
-	margin-bottom: 0;
 }
 
 /* Styles for marker and Dashicon variations [open]*/
@@ -55,7 +31,7 @@
 details.wp-block-details[class*="is-style-"]:not([class*="is-style-default"]) summary {
 	list-style: none;
 	position: relative;
-	padding-left: 1.25rem;
+	padding-left: 1.125rem;
 }
 
 details.wp-block-details[class*="is-style-"]:not([class*="is-style-default"]) summary::-webkit-details-marker {
@@ -67,7 +43,7 @@ details.wp-block-details[class*="is-style-"]:not([class*="is-style-default"]) su
 	font-family: dashicons, sans-serif;
 	position: absolute;
 	top: 1.3em;
-	left: 0.1em;
+	left: 0;
 	margin-top: -1.3em;
 }
 

--- a/wp-blocks/details.css
+++ b/wp-blocks/details.css
@@ -31,7 +31,7 @@
 details.wp-block-details[class*="is-style-"]:not([class*="is-style-default"]) summary {
 	list-style: none;
 	position: relative;
-	padding-left: 1.125rem;
+	padding-left: 1.125em;
 }
 
 details.wp-block-details[class*="is-style-"]:not([class*="is-style-default"]) summary::-webkit-details-marker {
@@ -45,45 +45,4 @@ details.wp-block-details[class*="is-style-"]:not([class*="is-style-default"]) su
 	top: 1.3em;
 	left: 0;
 	margin-top: -1.3em;
-}
-
-/* Styles for Dashicon variations */
-details.wp-block-details:not([class*="is-style-default"]).has-small-font-size summary {
-	padding-left: 1rem;
-}
-
-details.wp-block-details:not([class*="is-style-default"]).has-base-font-size summary {
-	padding-left: 1.25rem;
-}
-
-details.wp-block-details:not([class*="is-style-default"]).has-one-font-size summary {
-	padding-left: 1.5rem;
-}
-
-details.wp-block-details:not([class*="is-style-default"]).has-two-font-size summary {
-	padding-left: 1.75rem;
-}
-
-details.wp-block-details:not([class*="is-style-default"]).has-three-font-size summary {
-	padding-left: 2rem;
-}
-
-details.wp-block-details:not([class*="is-style-default"]).has-four-font-size summary {
-	padding-left: 2.25rem;
-}
-
-details.wp-block-details:not([class*="is-style-default"]).has-five-font-size summary {
-	padding-left: 2.75rem;
-}
-
-details.wp-block-details:not([class*="is-style-default"]).has-six-font-size summary {
-	padding-left: 3.25rem;
-}
-
-details.wp-block-details:not([class*="is-style-default"]).has-seven-font-size summary {
-	padding-left: 4rem;
-}
-
-details.wp-block-details:not([class*="is-style-default"]).has-eight-font-size summary {
-	padding-left: 5.5rem;
 }

--- a/wp-blocks/details.css
+++ b/wp-blocks/details.css
@@ -1,0 +1,113 @@
+.wp-block-details {
+	box-sizing: border-box;
+	overflow: hidden;
+}
+
+.wp-block-details summary {
+	cursor: pointer;
+}
+
+.wp-block-details.is-style-default summary {
+	padding-left: 0.5rem;
+}
+
+.wp-block-details.is-style-chevron summary::before {
+	content: "\f345";
+}
+
+.wp-block-details.is-style-plus summary::before {
+	content: "\f543";
+}
+
+.wp-block-details.is-style-check summary::before {
+	content: "\f147";
+}
+
+.wp-block-details summary > * {
+	display: inline;
+}
+
+/* Use block gap for block; falls back to browser default if not supported. */
+.wp-block-details > *:not(summary) {
+	margin-block-start: 0;
+	margin-block-end: 0;
+}
+
+/* Remove excess margin from the last block. */
+.wp-block-details > *:last-child {
+	margin-bottom: 0;
+}
+
+/* Styles for marker and Dashicon variations [open]*/
+.wp-block-details[open].is-style-chevron summary::before {
+	content: "\f347";
+}
+
+.wp-block-details[open].is-style-plus summary::before {
+	content: "\f460";
+}
+
+.wp-block-details[open].is-style-check summary::before {
+	content: "\f335";
+}
+
+/* Add Dashicons to non-default styles */
+details.wp-block-details[class*="is-style-"]:not([class*="is-style-default"]) summary {
+	list-style: none;
+	position: relative;
+	padding-left: 1.25rem;
+}
+
+details.wp-block-details[class*="is-style-"]:not([class*="is-style-default"]) summary::-webkit-details-marker {
+	display: none;
+}
+
+details.wp-block-details[class*="is-style-"]:not([class*="is-style-default"]) summary::before {
+	color: currentcolor;
+	font-family: dashicons, sans-serif;
+	position: absolute;
+	top: 1.3em;
+	left: 0.1em;
+	margin-top: -1.3em;
+}
+
+/* Styles for Dashicon variations */
+details.wp-block-details:not([class*="is-style-default"]).has-small-font-size summary {
+	padding-left: 1rem !important;
+}
+
+details.wp-block-details:not([class*="is-style-default"]).has-base-font-size summary {
+	padding-left: 1.25rem !important;
+}
+
+details.wp-block-details:not([class*="is-style-default"]).has-one-font-size summary {
+	padding-left: 1.5rem !important;
+}
+
+details.wp-block-details:not([class*="is-style-default"]).has-two-font-size summary {
+	padding-left: 1.75rem !important;
+}
+
+details.wp-block-details:not([class*="is-style-default"]).has-three-font-size summary {
+	padding-left: 2rem !important;
+}
+
+details.wp-block-details:not([class*="is-style-default"]).has-four-font-size summary {
+	padding-left: 2.25rem !important;
+}
+
+details.wp-block-details:not([class*="is-style-default"]).has-five-font-size summary {
+	padding-left: 2.75rem !important;
+}
+
+details.wp-block-details:not([class*="is-style-default"]).has-six-font-size summary {
+	padding-left: 3.25rem !important;
+}
+
+details.wp-block-details:not([class*="is-style-default"]).has-seven-font-size summary {
+	padding-left: 4rem !important;
+}
+
+details.wp-block-details:not([class*="is-style-default"]).has-eight-font-size summary {
+	padding-left: 5.5rem !important;
+}

--- a/wp-blocks/details.css
+++ b/wp-blocks/details.css
@@ -73,41 +73,41 @@ details.wp-block-details[class*="is-style-"]:not([class*="is-style-default"]) su
 
 /* Styles for Dashicon variations */
 details.wp-block-details:not([class*="is-style-default"]).has-small-font-size summary {
-	padding-left: 1rem !important;
+	padding-left: 1rem;
 }
 
 details.wp-block-details:not([class*="is-style-default"]).has-base-font-size summary {
-	padding-left: 1.25rem !important;
+	padding-left: 1.25rem;
 }
 
 details.wp-block-details:not([class*="is-style-default"]).has-one-font-size summary {
-	padding-left: 1.5rem !important;
+	padding-left: 1.5rem;
 }
 
 details.wp-block-details:not([class*="is-style-default"]).has-two-font-size summary {
-	padding-left: 1.75rem !important;
+	padding-left: 1.75rem;
 }
 
 details.wp-block-details:not([class*="is-style-default"]).has-three-font-size summary {
-	padding-left: 2rem !important;
+	padding-left: 2rem;
 }
 
 details.wp-block-details:not([class*="is-style-default"]).has-four-font-size summary {
-	padding-left: 2.25rem !important;
+	padding-left: 2.25rem;
 }
 
 details.wp-block-details:not([class*="is-style-default"]).has-five-font-size summary {
-	padding-left: 2.75rem !important;
+	padding-left: 2.75rem;
 }
 
 details.wp-block-details:not([class*="is-style-default"]).has-six-font-size summary {
-	padding-left: 3.25rem !important;
+	padding-left: 3.25rem;
 }
 
 details.wp-block-details:not([class*="is-style-default"]).has-seven-font-size summary {
-	padding-left: 4rem !important;
+	padding-left: 4rem;
 }
 
 details.wp-block-details:not([class*="is-style-default"]).has-eight-font-size summary {
-	padding-left: 5.5rem !important;
+	padding-left: 5.5rem;
 }

--- a/wp-blocks/styles.js
+++ b/wp-blocks/styles.js
@@ -99,4 +99,17 @@ wp.domReady( () => {
 			height: '4rem',
 		},
 	} );
+	// Styles for core/details
+	wp.blocks.registerBlockStyle( 'core/details', {
+		name: 'chevron',
+		label: 'Chevron',
+	} );
+	wp.blocks.registerBlockStyle( 'core/details', {
+		name: 'plus',
+		label: 'Plus/Minus',
+	} );
+	wp.blocks.registerBlockStyle( 'core/details', {
+		name: 'check',
+		label: 'Check mark',
+	} );
 } );


### PR DESCRIPTION
## What does this do/fix?

Adds a style-sheet for the **Details Block** with custom options. Edit style-sheet for **Accordion Block** to only target a class, not the `<details>` element itself. See description in Issue #305 

## QA

Links to relevant issues
- Fixes #305 

Screenshots/video:

Details front-end closed
![details-variations-closed](https://github.com/ucsc/ucsc-2022/assets/1000543/de1d6da9-ae21-49d2-848c-834dd5e8e1f8)

Details front-end open
![details-variations-open](https://github.com/ucsc/ucsc-2022/assets/1000543/acbe9d55-7509-4d1a-bdee-34c1686b4a5f)

Accordion front-end closed
![accordion-closed](https://github.com/ucsc/ucsc-2022/assets/1000543/1b60a38c-d66b-499e-8ee0-4ae09b6e5491)

Accordion front-end open
![accordion-open](https://github.com/ucsc/ucsc-2022/assets/1000543/756371a3-6bd7-4171-9b0b-dad8512c9cee)

Accordion in the Block Editor
![accordion-block-editor](https://github.com/ucsc/ucsc-2022/assets/1000543/d1778bce-cd23-4236-80b4-6a4d3ad12fb0)

Details in the Block Editor
![details-block-editor](https://github.com/ucsc/ucsc-2022/assets/1000543/663c3d06-596b-4909-b876-aa2fd1c031c4)

Details Styles
![details-editor-styles](https://github.com/ucsc/ucsc-2022/assets/1000543/fb70603f-79de-4749-be1d-1b30e30d0b4b)
