### PR TITLE
Add list style marker options for list block. Fixes #304

### DIFF
--- a/wp-blocks/list.css
+++ b/wp-blocks/list.css
@@ -29,16 +29,20 @@
 	border-bottom: none;
 }
 
+.is-style-ucsc-upper-alpha-list > li {
+	list-style-type: upper-alpha;
+}
+
+.is-style-ucsc-lower-alpha-list > li {
+	list-style-type: lower-alpha;
+}
+
+.is-style-ucsc-lower-roman-list > li {
+	list-style-type: lower-roman;
+}
+
 .site-content ul li,
 .site-content ol li {
 	margin: calc(var(--wp--style--block-gap) / 2) 0;
 	line-height: var(--wp--custom--line-height--baseline);
-}
-
-.is-style-ucsc-upper-alpha-list {
-	list-style-type: upper-alpha;
-}
-
-.is-style-ucsc-lower-alpha-list {
-	list-style-type: lower-alpha;
 }

--- a/wp-blocks/styles.js
+++ b/wp-blocks/styles.js
@@ -24,6 +24,11 @@ wp.domReady( () => {
 		label: 'Lower alpha',
 		style_handle: 'ucsc-list',
 	} );
+	wp.blocks.registerBlockStyle( 'core/list', {
+		name: 'ucsc-lower-roman-list',
+		label: 'Lower roman',
+		style_handle: 'ucsc-list',
+	} );
 	// Styles for core/button
 	wp.blocks.registerBlockStyle( 'core/button', {
 		name: 'ucsc-blue',


### PR DESCRIPTION
## What does this do/fix?

Adds one additional list style option for ordered and unordered lists in the list block. Nested lists can be assigned different list markers.

## QA

Links to relevant issues
- [Issue 304](https://github.com/ucsc/ucsc-2022/issues/304)

## Tests

- [ ] Add several nested lists to a page and select different styles for each
