### PR TITLE
fix: 📝 page-no-title template is only for pages, not posts

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -532,8 +532,7 @@
 		{
 			"name": "page-no-title",
 			"postTypes": [
-				"page",
-				"post"
+				"page"
 			],
 			"title": "Page no title"
 		}


### PR DESCRIPTION
## What does this do/fix?

Removes `page-no-title` template as an option for posts.

## Tests

Does this have tests?

- [ ] Yes
- [x] No, this doesn't need tests because...
- [ ] No, I need help figuring out how to write the tests.
