### PR TITLE
Add preconfigured vertical gradient for text over images  Fixes #291

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -38,6 +38,11 @@
 					"name": "UCSC Light Gradient",
 					"gradient": "linear-gradient(180deg, #ffffff 0%, #f2f2f2 100%)",
 					"slug": "ucsc-light-gradient"
+				},
+				{
+					"name": "UCSC Image with Text Gradient",
+					"gradient": "linear-gradient(180deg, transparent 0%, #f2f2f2 30%, #000 90%)",
+					"slug": "ucsc-text-over-image-gradient"
 				}
 			],
 			"palette": [


### PR DESCRIPTION
## What does this do/fix?

Adds a preconfigured vertical gradient to use when placing text over an image.

## Tests

- Look for a 4th preconfigured choice in the gradient panel of the color chooser.