### PR TITLE
Feat: 🎉 Remove the grow effect from linked Icon Block SVG images

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'ucsc_setup' ) ) :
 		/*
 		* Load additional Core block styles.
 		*/
-		$styled_blocks = array( 'core/button', 'core/columns', 'core/post-template', 'core/post-author', 'core/site-title', 'core/query-pagination', 'core/post-content', 'core/rss', 'core/post-title', 'core/post-comments', 'core/navigation', 'core/list', 'core/separator', 'core/latest-posts', 'core/quote', 'core/image', 'core/search', 'core/paragraph', 'ucscblocks/accordion', 'core/details' );
+		$styled_blocks = array( 'core/button', 'core/columns', 'core/post-template', 'core/post-author', 'core/site-title', 'core/query-pagination', 'core/post-content', 'core/rss', 'core/post-title', 'core/post-comments', 'core/navigation', 'core/list', 'core/separator', 'core/latest-posts', 'core/quote', 'core/image', 'core/search', 'core/paragraph', 'ucscblocks/accordion', 'core/details','outermost/icon-block' );
 		foreach ( $styled_blocks as $block ) {
 
 			$name = explode('/', $block);

--- a/wp-blocks/icon-block.css
+++ b/wp-blocks/icon-block.css
@@ -1,0 +1,3 @@
+.is-style-remove-hover a:hover {
+	transform: none;
+}

--- a/wp-blocks/styles.js
+++ b/wp-blocks/styles.js
@@ -117,4 +117,9 @@ wp.domReady( () => {
 		name: 'check',
 		label: 'Check mark',
 	} );
+	// Style for outermost/icon-block
+	wp.blocks.registerBlockStyle( 'outermost/icon-block', {
+		name: 'remove-hover',
+		label: 'Remove hover',
+	} );
 } );


### PR DESCRIPTION
Fixes #292

## What does this do/fix?

Adds a style option to the Icon Block to remove the "grow" transition on hover when it is used as a link. 

## QA

Links to relevant issues
- #292 

Screenshots/video:
![remove-hover](https://github.com/ucsc/ucsc-2022/assets/1000543/48ca34ce-0255-4cc1-9408-a964ac17e134)

## Tests

- [ ] Add SVG icon via Icon Block. Select "Remove hover" style. Review on front end.
