### PR TITLE
fix(styles): Balanced text-wrap change from 'balanced' to ‘pretty’

### DIFF
--- a/src/scss/base/_normalize.scss
+++ b/src/scss/base/_normalize.scss
@@ -14,6 +14,6 @@ h3,
 h4,
 h5,
 h6 {
-	text-wrap: balance;
+	text-wrap: pretty;
 }
 


### PR DESCRIPTION
Fixes #320