### PR TITLE
Fix: 🐛 Add ARIA landmark role for the `last-modified` date

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -370,7 +370,7 @@ add_action('wp_footer', 'ucsc_last_modified', 10);
 
 function ucsc_last_modified()
 {
-	echo '<!-- Last modified code.  --><div class="last-modified__outer" ><div class="last-modified__inner"><div class="last-modified">Last modified: ';
+	echo '<!-- Last modified code.  --><div class="last-modified__outer" role="region" aria-label="Page last modification date" ><div class="last-modified__inner"><div class="last-modified" >Last modified: ';
 	echo do_shortcode('[last-modified]');
 	echo '</div></div></div><!-- End last modified code.  -->';
 }


### PR DESCRIPTION
## What does this do/fix?

Adds Landmark `role="region"` and `aria-label="Page last modification date"` attributes to **Last modified** text at bottom of footer. Fixes #327

## QA

Links to relevant issues
- #327 

Screenshots/video:

![last-modified-aria](https://github.com/ucsc/ucsc-2022/assets/1000543/d1c89520-549e-4a2e-ad20-106c72d39fa0)

![accessibility-attributes](https://github.com/ucsc/ucsc-2022/assets/1000543/db28c6ec-2fac-45e0-9484-34bd29a11d7e)

## Tests

Does this have tests?

- [ x ] Yes. Build theme locally and use element inspector and accessibility panel to review. Ultimate test will be SiteImprove results.
