### PR TITLE
fix: :alembic: Change breadcrumbs list tag to `<ol>`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -276,6 +276,7 @@ function ucsc_breadcrumbs_constructor()
 		'labels' => $labels,
 		'show_on_front' => true,
 		'show_trail_end' => true,
+		'list_tag'        => 'ol',
 		'container_class' => 'ucsc-page-header__breadcrumbs',
 	];
 	return Hybrid\Breadcrumbs\Trail::render($args);


### PR DESCRIPTION
Hoping this adds a `position` attribute to list items.

## What does this do/fix?

This is a test to possibly fix issue #330 . It changes the `list_tag` to `ol` in the `$args` array in the Breadcrumbs constructor. 

The idea is that an "ordered list" will add a "position" attribute to its list items. The way to test this is to implement it and then go into Google Search Console and issue a "fix."

If it doesn't work, we need to re-evaluate.

