### PR TITLE
Feat: 🎉 Add zoom transition on linked image hover

### DIFF
--- a/src/scss/block-patterns/_cards.scss
+++ b/src/scss/block-patterns/_cards.scss
@@ -22,28 +22,6 @@
 	height: 100%;
 }
 
-/* Card images */
-:where(.ucsc__card .wp-block-image),
-:where(.ucsc__card .wp-block-post-featured-image) {
-
-	a {
-		display: block;
-		overflow: hidden;
-
-		img {
-			transition: transform 0.3s ease;
-		}
-
-		&:hover,
-		&:focus {
-
-			img {
-				transform: scale(1.15);
-			}
-		}
-	}
-}
-
 /* Links in card overlines and titles */
 :where(.ucsc__card .has-small-font-size:first-child),
 :where(.ucsc__card .wp-block-image + .has-small-font-size),

--- a/src/scss/elements/_links.scss
+++ b/src/scss/elements/_links.scss
@@ -61,3 +61,29 @@ a {
 		scroll-margin-top: 11rem;
 	}
 }
+
+/* Linked Images hover and focus transition  */
+:where(.wp-block-image),
+:where(.wp-block-post-featured-image),
+:where(.wp-block-media-text__media) {
+
+	a {
+		display: block;
+		overflow: hidden;
+
+		img {
+			transition: transform 0.3s ease;
+		}
+
+		&:hover,
+		&:focus {
+
+			img {
+				transform: scale(1.15);
+				@media screen and (prefers-reduced-motion: reduce) {
+			  	transform: none;
+				}
+			}
+		}
+	}
+}

--- a/src/scss/elements/_links.scss
+++ b/src/scss/elements/_links.scss
@@ -61,8 +61,15 @@ a {
 		scroll-margin-top: 11rem;
 	}
 }
+/**
+	* Linked Images hover, focus, active transition
+	*/
 
-/* Linked Images hover and focus transition  */
+/**
+	* Figure elements that have linked images
+	* transition on hover, focus and active
+	* unless a user "prefers reduced motion."
+	*/
 figure:has(a) {
 	a {
 		overflow: hidden;
@@ -86,6 +93,11 @@ figure:has(a) {
 	}
 }
 
+/**
+	* Figure elements that have linked background images
+	* transition on hover, focus and active
+	* unless a user "prefers reduced motion."
+	*/
 figure[style^="background-image"]:has(a) {
 	transition: all 0.3s ease;
 	background-size: 100% !important;

--- a/src/scss/elements/_links.scss
+++ b/src/scss/elements/_links.scss
@@ -105,8 +105,23 @@ figure[style^="background-image"]:has(a) {
 		&:hover,
 		&:active {
 			background-size:115% !important;
-			@media screen and (prefers-reduced-motion: reduce) {
-				background-size: 100%;
-			}
 		}
 	}
+
+/**
+	* Prefers reduced motion media query
+	*
+	* With a background image, the entire figure element
+	* needs to be wrapped in the media query
+	*
+	*/
+@media screen and (prefers-reduced-motion: reduce) {
+	figure[style^="background-image"]:has(a) {
+		background-size: 100% !important;
+			&:focus,
+			&:hover,
+			&:active {
+				background-size:100% !important;
+			}
+		}
+}

--- a/src/scss/elements/_links.scss
+++ b/src/scss/elements/_links.scss
@@ -63,9 +63,6 @@ a {
 }
 
 /* Linked Images hover and focus transition  */
-:where(.wp-block-image),
-:where(.wp-block-post-featured-image),
-:where(.wp-block-media-text__media) {
 
 	a {
 		display: block;
@@ -86,4 +83,11 @@ a {
 			}
 		}
 	}
-}
+figure[style^="background-image"]:has(a) {
+	transition: transform 0.3s ease;
+	&:hover,
+	&:focus {
+		// transform: scale(1.15);
+		background-size:115%!important;
+	}
+	}

--- a/src/scss/elements/_links.scss
+++ b/src/scss/elements/_links.scss
@@ -63,17 +63,18 @@ a {
 }
 
 /* Linked Images hover and focus transition  */
-
+figure:has(a) {
 	a {
-		display: block;
 		overflow: hidden;
+		display:block;
 
 		img {
 			transition: transform 0.3s ease;
 		}
 
+		&:focus,
 		&:hover,
-		&:focus {
+		&:active {
 
 			img {
 				transform: scale(1.15);
@@ -83,11 +84,17 @@ a {
 			}
 		}
 	}
+}
+
 figure[style^="background-image"]:has(a) {
-	transition: transform 0.3s ease;
-	&:hover,
-	&:focus {
-		// transform: scale(1.15);
-		background-size:115%!important;
-	}
+	transition: all 0.3s ease;
+	background-size: 100% !important;
+		&:focus,
+		&:hover,
+		&:active {
+			background-size:115% !important;
+			@media screen and (prefers-reduced-motion: reduce) {
+				background-size: 100%;
+			}
+		}
 	}


### PR DESCRIPTION
## What does this do/fix?

Adjust styles to add a zoom transition on all linked images (images wrapped in an `<a>` tag). 

This effect was included in the **UCSC Query Card** developed by Modern Tribe. This PR incorporates that behavior on every linked image. The redundant code was removed from the UCSC Query Card. 

Additionally, this code includes the "prefers-reduced-motion" media query, which allows a user to disable this effect via their OS.

## QA

Links to relevant issues
- Issue #340 


Screenshots/video:
https://github.com/user-attachments/assets/d0168da2-bde0-4362-9bdf-205db3554a56


## Tests

Does this have tests?

- [x] Yes, see video. These are CSS changes. It's tested by building, then using one's OS settings to reduce motion.
