### PR TITLE
Added check for block before unregistering.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -1,35 +1,39 @@
-<?php
+<?php declare(strict_types=1);
 
-add_action( 'init', function () {
+add_action( 'init', static function (): void {
 	// Register custom blocks from Advanced Custom Fields
 	register_block_type( get_template_directory() . '/blocks/main-nav' );
 	register_block_type( get_template_directory() . '/blocks/breadcrumbs' );
 
- 	// Remove core block patterns
+	// Remove core block patterns
 	remove_theme_support( 'core-block-patterns' );
 
 	// Remove included patterns that line 8 doesn't remove
-	unregister_block_pattern( 'core/social-links-shared-background-color' );
-	unregister_block_pattern( 'core/query-large-title-posts' );
+	if ( has_block( 'core/social-links-shared-background-color' ) ) {
+		unregister_block_pattern( 'core/social-links-shared-background-color' );
+	}
+	if ( has_block( 'core/query-large-title-posts ' ) ) {
+		unregister_block_pattern( 'core/query-large-title-posts' );
+	}
 
 	// Register Block Categories
 	register_block_pattern_category(
 		'page_layout',
-		array( 'label' => __( 'Page Layout', 'ucsc' ) )
+		[ 'label' => __( 'Page Layout', 'ucsc' ) ]
 	);
 
 	register_block_pattern_category(
 		'text_layout',
-		array( 'label' => __( 'Text Layout', 'ucsc' ) )
+		[ 'label' => __( 'Text Layout', 'ucsc' ) ]
 	);
 
 	register_block_pattern_category(
 		'banner',
-		array( 'label' => __( 'Banner', 'ucsc' ) )
+		[ 'label' => __( 'Banner', 'ucsc' ) ]
 	);
 
 	register_block_pattern_category(
 		'grid',
-		array( 'label' => __( 'Grid', 'ucsc' ) )
+		[ 'label' => __( 'Grid', 'ucsc' ) ]
 	);
 } );


### PR DESCRIPTION
## What does this do/fix?

Fixes the following notice when attempting to unregister a block that's not present:

`Notice: Function WP_Block_Patterns_Registry::unregister was called incorrectly. Pattern "core/social-links-shared-background-color" not found`