### PR TITLE
Fix: 🚑 Layout grid element needs a grid columns rule

### DIFF
--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -9,9 +9,9 @@ body {
 }
 
 .wp-site-blocks {
-	flex: 1 0 auto;
 	display: grid;
 	grid-template-rows: auto 1fr auto;
+	grid-template-columns: 100%;
 
 	&:has(.breadcrumbs-region) {
 		grid-template-rows: auto auto 1fr auto;


### PR DESCRIPTION
Fixes #370

## What does this do/fix?

This fixes a common issue in the UCSC 2022 where the body element shrinks below the width of the window due to a child element with a fixed minimum width tht won't shrink with it. 

The addition of a grid-template-columns rule on the `.wp-site-blocks` element resolves this problem by preventing it from shrinking below 100% of the window width. 