### PR TITLE
fix: 🐛 Remove image hover effect rules from caption links

### DIFF
--- a/src/scss/elements/_links.scss
+++ b/src/scss/elements/_links.scss
@@ -73,7 +73,7 @@ a {
 	*/
 	figure:has(a),
 	.wp-block-latest-posts__featured-image:has(a) {
-	a {
+	a:has(img) {
 		overflow: hidden;
 		display: block;
 


### PR DESCRIPTION
Images with links *in their captions* were getting style rules intended only for linked images. Fixes #373