### PR TITLE
feat: ✨ Template part and styles for the 'eyebrow' affiliation link

### DIFF
--- a/parts/site-title-with-affiliation.html
+++ b/parts/site-title-with-affiliation.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph {"className":"ucsc-eyebrow","style":{"elements":{"link":{"color":{"text":"var:preset|color|lightest-gray"},":hover":{"color":{"text":"var:preset|color|ucsc-primary-blue"}}}},"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"400","textDecoration":"none"},"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}},"textColor":"white"} -->
+<p class="ucsc-eyebrow has-white-color has-text-color has-link-color" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;font-style:normal;font-weight:400;text-decoration:none;text-transform:uppercase"><a href="https://news.ucsc.edu">Affiliation</a></p>
+<!-- /wp:paragraph -->
+<!-- wp:site-title {"level":0,"style":{"spacing":{"margin":{"right":"0","left":"0","top":"0","bottom":"0"}}},"textColor":"white","fontSize":"six"} /--></div>
+<!-- /wp:group -->

--- a/src/scss/elements/_links.scss
+++ b/src/scss/elements/_links.scss
@@ -127,3 +127,21 @@ figure[style^="background-image"]:has(a) {
 		}
 	}
 }
+
+/**
+* Styles for the 'eyebrow,' a small
+* affiliation link above the site title
+*/
+.site-header .ucsc-eyebrow a {
+	text-decoration: unset;
+	transition: all 0.3s ease;
+
+	&:focus,
+	&:hover,
+	&:active {
+		box-shadow: 0 0 0 2px var(--wp--preset--color--white);
+		background-color: var(--wp--preset--color--white);
+		z-index: 1;
+		color: var(--wp--preset--color--ucsc-primary-blue);
+	}
+}


### PR DESCRIPTION
## What does this do/fix?

This adds a template part called "site title with affiliation link" and coorespnding styles for the affiliation link above the site title in the site header. 

## Tests

To test and use this, edit your site header to remove the default site title block. then insert the template part included with this PR. 

Be sure to compile styles before testing.

![screenshot-2025-05-06-163729](https://github.com/user-attachments/assets/7cfa370b-ca4c-4b33-b51e-a2de81c8bf68)

![screenshot-2025-05-06-163557](https://github.com/user-attachments/assets/88160639-3ef3-46c7-a26a-239f78b54626)