### PR TITLE
fix: 🐛 Add `flex` back to `.wp-site-blocks` element

### DIFF
--- a/src/scss/base/_layout.scss
+++ b/src/scss/base/_layout.scss
@@ -10,6 +10,7 @@ body {
 
 .wp-site-blocks {
 	display: grid;
+	flex: 1 0 auto;
 	grid-template-rows: auto 1fr auto;
 	grid-template-columns: 100%;
 


### PR DESCRIPTION
Fixes #378

Does what it says on the tin. To test, create a short page and view it in a tall browser window. The main content portion of the page should fill the page with the footer at the bottom of the browser window.
