### PR TITLE
Opt-in to CSS view transitions  Fixes #381

### DIFF
--- a/style.css
+++ b/style.css
@@ -18,3 +18,9 @@ GitHub Theme URI: http://github.com/ucsc/ucsc-2022
 body * {
 	box-sizing: border-box;
 }
+
+@media (prefers-reduced-motion: no-preference) {
+	@view-transition {
+		navigation: auto;
+	}
+}


### PR DESCRIPTION
## What does this do/fix?

Opts the theme in to [CSS View Transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_view_transitions), which smooth the transition from page to page in [browsers that support them](https://caniuse.com/mdn-css_at-rules_view-transition).


## Tests

In Chromium-based browsers, and recent versions of Safari, pages should smoothly transition, even full page loads.