### PR TITLE
Update Truss URL and version in theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -364,8 +364,8 @@ function ucsc_truss_assets()
 ?>
 
 	<!-- Script and style to include our components library, Truss.  -->
-	<script type="module" src="https://unpkg.com/@ucsantacruz/truss@0.8.2/dist/ucsc-trss/ucsc-trss.esm.js"></script>
-	<link rel="stylesheet" href="https://unpkg.com/@ucsantacruz/truss@0.8.2/dist/ucsc-trss/ucsc-trss.css">
+	<script type="module" src="https://ucsc-truss.netlify.app/ucsc-trss/ucsc-trss.esm.js"></script>
+	<link rel="stylesheet" href="https://ucsc-truss.netlify.app/ucsc-trss/ucsc-trss.css">
 <?php
 }
 


### PR DESCRIPTION
Fixes #382

This change updates the URL for [Truss](https://github.com/ucsc/truss) to a version-less URL on our Netlify CDN. There should not be any effect on the user experience.

## Tests

Verify that Truss assets load from:

`https://ucsc-truss.netlify.app`

instead of:

`https://unpkg.com/@ucsantacruz/truss@0.8.2/`